### PR TITLE
Set up public deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Prep for pages build
+
+on:
+    push:
+        branches:
+            - main
+    
+    workflow_dispatch:  # Allow manual re-run from Actions tab
+
+
+
+jobs:
+    build-webpack:
+        name: Generate webpack build artifacts
+        permissions:
+            contents: write # Allow to push artifacts back to remote
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+            - uses: actions/setup-node@v4
+              with:
+                node-version: 18
+                cache: npm
+            
+            - name: Configure git
+              run: |
+                git config --global user.name 'Actions: Deploy to Pages'
+                git config --global user.email 'actions-pages-deploy@users.noreply.github.com'
+                git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+            
+            - name: Install dependencies
+              run: npm ci
+            - name: Generate build artifacts
+              run: npm run build
+
+            - name: Move static artifacts
+              run: mv -v ./static/* ./docs/
+            
+            - name: Push changes
+              run: |
+                git add docs/*
+                git commit -m "Action: Build for Pages deploy"
+                git push

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # For storing notes and other custom non-tracked things
 ~local/*
 
+### MacOS ###
+.DS_Store
+
 ### Node ###
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -1,7 +1,25 @@
-# model-authoring-prototype-internal
-Internal repository for prototypes of an example implementation of an OpenDI-compliant CDM/CDD authoring frontend system.
+# CDD Authoring Tool
+This repo holds a publicly-useable prototype of an OpenDI-compliant CDM/CDD authoring frontend tool.
 
-# Setup
+This is meant as an example implementation of OpenDI standards and resources.
+
+# Live Test
+You can try this tool out yourself!  
+Visit https://opendi.org/cdd-authoring-tool/  
+See warning below.
+
+## Warning
+This tool is a prototype!  
+We cannot yet guarantee that the system is bug-free. The tool may crash unexpectedly, and you may lose data.
+
+The tool provides a Download button to save your work to a JSON file. Use this often!  
+To use your own JSON file as a starting point:  
+1. Delete all contents in the tool's JSON view.
+2. Open your JSON file in a text editor.
+3. Copy the entire text contents of the JSON file.
+4. Paste into the frontend tool's JSON view.
+
+# Setup for Local Testing
 
 To setup, clone this repo to a local directory. Then:  
 1. [Install npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). This setup was initially performed on npm v9.6.6, and Node.js v18.16.0

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
     entry: './src/index.js',                    //Relative path to entry file
     output: {
-        path: path.resolve(__dirname, 'dist'),  //Output bundled script file in ./dist/
+        path: path.resolve(__dirname, 'docs'),  //Output bundled script file in ./dist/
         filename: 'bundled_app.js'              //Name of bundled script file
     },
     mode: 'development',                        //Webpack yells at you if you don't set a mode


### PR DESCRIPTION
Set up for project to be hosted as part of the OpenDI GitHub Pages site.
This should build and deploy to https://opendi.org/cdd-authoring-tool


Added GitHub Actions workflow that attempts to re-generate the build artifacts whenever a new push to main occurs. Build artifacts will be placed into docs/.
GitHub Pages should be configured to automatically build from this folder's contents on the main branch.

Updated README.md with instructions/warnings for testing this live.

Also updated gitignore for MacOS system files.