### PR TITLE
Minor fixes: typo, new dependencies always un-selected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -454,7 +454,6 @@ function deleteElements(selectionBuffer, runtimeGraphData)
 
 /**
  * Creates a fresh dependency with the given source and target elements, and adds it to the given graph.
- * NOTE: This function does not add the dependency to the JSON editor view.
  * 
  * Used here:
  * @see toggleDependency
@@ -483,6 +482,7 @@ function addNewDependency(sourceElem, targetElem, runtimeGraphData, graph)
     };
 
     runtimeGraphData.graphLinks[newDepUUID] = CausalDependency.addLinkToGraph(addDepJSON, graph, runtimeGraphData.graphElements);
+    runtimeGraphData.graphLinks[newDepUUID].updateSelection();
 }
 
 /**

--- a/src/schema_compliant_cdd.json
+++ b/src/schema_compliant_cdd.json
@@ -5,7 +5,7 @@
       "name": "Coffee purchasing decision",
       "summary": "For deciding whether to purchase regular or fair trade coffee, and how much. CDD models the impact to workers and environment, to ultimately track social/environmental and financial impacts as main outcomes.",
       "documentation": {
-        "content": "This CDD authored by Dr. Lorien Pratt.\nSource: https://www.lorienpratt.com/a-framework-for-how-data-informs-decisions/\n\nAdapted for OpenDI schema compliance by Isaac Kellogg.",
+        "content": "This CDD was authored by Dr. Lorien Pratt.\nSource: https://www.lorienpratt.com/a-framework-for-how-data-informs-decisions/\n\nAdapted for OpenDI schema compliance by Isaac Kellogg.",
         "MIMEType": "text/plain"
       },
       "draft": true,


### PR DESCRIPTION
Fixed minor typo in default CDD documentation.

Fixed #17 where new dependencies created with the "toggle dependency" UI button were not highlighted, despite both related elements being selected.