### PR TITLE
Improved build and deploy process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
             - uses: actions/checkout@v4
               with:
                 fetch-depth: 0
-                ssh-key: ${{secrets.DEPLOY_KEY}}
             - uses: actions/setup-node@v4
               with:
                 node-version: 18
@@ -37,8 +36,15 @@ jobs:
             - name: Generate build artifacts
               run: npm run build
 
+              # Put built site in the gh-pages branch for deployment
             - name: Move static artifacts
-              run: mv -v ./static/* ./docs/
+              # Move site files out of repo, switch branches, replace old site build files with new files
+              run: |
+                mkdir ../TEMP
+                mv ./static ../TEMP/docs
+                git switch gh-pages
+                rm -rf ./docs/
+                mv ../TEMP/docs ./docs
             
             - name: Push changes
               run: |


### PR DESCRIPTION
Made deploy process more similar to other OpenDI projects. See https://github.com/opendi-org/opendi-org.github.io/blob/6e52e1b33184c9e63995eb1ae46300697c4f869b/.github/workflows/build-for-deployment.yml for example

Deploy action now uses `main` branch in a read-only capacity: Uses `main` source to generate static built files, then pushes only those files to `gh-pages` branch.

This repo will now be reconfigured to deploy Pages from that branch.