### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" #yarn
+    schedule:
+      interval: "weekly"
+    directory: "/"
+    target-branch: "dev"


### PR DESCRIPTION
Dependabot will now check for new package versions weekly, and will make PRs to dev.