### PR TITLE
Remove dependency: webpack-server (for security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
       "devDependencies": {
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.4",
-        "webpack-server": "^0.1.2"
+        "webpack-dev-server": "^5.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -910,16 +909,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "license": "BSD-3-Clause OR MIT",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -963,13 +952,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -978,23 +960,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/base62": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-      "integrity": "sha512-QtExujIOq/F672OkHmDi3CdkphOA1kSQ38gv03Ro3cplYQk831dq9GM3Q1oXAxpR5HNJjGjjjT2pHtBGAJu1jw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/basic-auth-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha512-kiV+/DTgVro4aZifY/hwRwALBISViL5NP4aReaR2EVJEObpbUBHIkdJh/YpcoEiYt7nBodZ6U2ajZeZvSxUCCg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -1108,15 +1073,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-      "integrity": "sha512-vMfBIRp/wjlpueSz7Sb0OmO7C5SH58SSmbsT8G4D48YfO/Zgbr29xNXMpZVSC14ujVJfrZZH1Bl+kXYRQPuvfQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1199,19 +1155,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/cli-color": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-      "integrity": "sha512-f4DFHXdoe2rGMwuVO+DTBM6CkSt4m9R4a0vjnq5CJkSCKaXbrHbslCmyjG6cz/o50HP2wkjO3G1mXvc7G3V1LQ==",
-      "dev": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2",
-        "memoizee": "~0.2.5"
-      },
-      "engines": {
-        "node": ">=0.1.103"
       }
     },
     "node_modules/clone-deep": {
@@ -1306,41 +1249,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/connect": {
-      "version": "2.14.5",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-2.14.5.tgz",
-      "integrity": "sha512-OY9UUEIqjPFdlnbby+1A2//0Bp4j0Mtjm3ARZr0QDrqXGm6slldQ/twgp0lCk+hEZbOeNE1J0QZqgQLC7I7ZYg==",
-      "deprecated": "connect 2.x series is deprecated",
-      "dev": true,
-      "dependencies": {
-        "basic-auth-connect": "1.0.0",
-        "bytes": "0.3.0",
-        "compression": "1.0.0",
-        "connect-timeout": "1.0.0",
-        "cookie-parser": "1.0.1",
-        "cookie-signature": "1.0.3",
-        "csurf": "1.1.0",
-        "debug": ">= 0.7.3 < 1",
-        "errorhandler": "1.0.0",
-        "express-session": "1.0.2",
-        "fresh": "0.2.2",
-        "method-override": "1.0.0",
-        "morgan": "1.0.0",
-        "multiparty": "2.2.0",
-        "pause": "0.0.1",
-        "qs": "0.6.6",
-        "raw-body": "1.1.4",
-        "response-time": "1.0.0",
-        "serve-index": "1.0.1",
-        "serve-static": "1.1.0",
-        "setimmediate": "1.0.1",
-        "static-favicon": "1.0.2",
-        "vhost": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -1349,189 +1257,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/connect-timeout": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.0.0.tgz",
-      "integrity": "sha512-W2VzhWNVueme6StiPMn3/1uN3UCvWKQ3T5tm9YSkfju9DqCahHGL99cgEURuse/88bo3AgS8PZtQuL0bLpoLcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "*"
-      }
-    },
-    "node_modules/connect/node_modules/batch": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
-      "integrity": "sha512-avtDJBSxllB5QGphW1OXYF+ujhy/yIGgeFsvK6UiZLU86nWlqsNcZotUKd001wrl9MmZ9QIyVy8WFVEEpRIc5A==",
-      "dev": true
-    },
-    "node_modules/connect/node_modules/bytes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz",
-      "integrity": "sha512-koasz05sePZ8FLtyBSyGGlrvr1DYqr+D/MFXkz9afRugTCGKuqw6fjWMMmaCWEKtmWpgOnaGI4qlw/hPyyYX6g==",
-      "dev": true
-    },
-    "node_modules/connect/node_modules/compressible": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz",
-      "integrity": "sha512-iy203MIJMtCucpPkRq5g0e8Y1lNTY2MJPMnqBDvL6zSW5lv7hFQAF+M1tAp2ujZ1C5eTGgjukj6oWrIodrBijA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect/node_modules/compression": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz",
-      "integrity": "sha512-CooBxyGghjsLjWUON1Ofvx13hYnsX/l9YyZeD/oq+aftiIYyou5bEn1FqCNA9j7wEtpptFe6Cw+TR1yZ/F19lQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "0.2.1",
-        "compressible": "1.0.0",
-        "negotiator": "0.3.0"
-      }
-    },
-    "node_modules/connect/node_modules/compression/node_modules/bytes": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
-      "integrity": "sha512-odbk8/wGazOuC1v8v4phoV285/yx8UN5kfQhhuxaVcceig4OUiCZQBtaEtmA1Q78QSTN9iXOQ7X2EViybrEvtQ==",
-      "dev": true
-    },
-    "node_modules/connect/node_modules/cookie-signature": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
-      "integrity": "sha512-/KzKzsm0OlguYov01OlOpTkX5MhBKUmfL/KMum7R80rPKheb9AwUzr78TwtBt1OdbnWrt4X+wxbTfcQ3noZqHw==",
-      "dev": true
-    },
-    "node_modules/connect/node_modules/debug": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-      "integrity": "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/connect/node_modules/fresh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
-      "integrity": "sha512-ZGGi8GROK//ijm2gB33sUuN9TjN1tC/dvG4Bt4j6IWrVGpMmudUBCxx+Ir7qePsdREfkpQC4FL8W0jeSOsgv1w==",
-      "dev": true
-    },
-    "node_modules/connect/node_modules/mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha512-Ysa2F/nqTNGHhhm9MV8ure4+Hc+Y8AWiqUdHxsO7xu8zc92ND9f3kpALHjaP026Ft17UfxrMt95c50PLUeynBw==",
-      "dev": true
-    },
-    "node_modules/connect/node_modules/negotiator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
-      "integrity": "sha512-q9wF64uB31BDZQ44DWf+8gE7y8xSpBdREAsJfnBO2WX9ecsutfUO6S9uWEdixlDLOlWaqnlnFXXwZxUUmyLfgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/connect/node_modules/parseurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
-      "integrity": "sha512-6W9+0+9Ihayqwjgp4OaLLqZ3KDtqPY2PtUPz8YNiy4PamjJv+7x6J9GO93O9rUZOLgaanTPxsKTasxqKkO1iSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect/node_modules/qs": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-      "integrity": "sha512-kN+yNdAf29Jgp+AYHUmC7X4QdJPR8czuMWLNLc0aRxkQ7tB3vJQEONKKT9ou/rW7EbqVec11srC9q9BiVbcnHA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/connect/node_modules/range-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-      "integrity": "sha512-nDsRrtIxVUO5opg/A8T2S3ebULVIfuh8ECbh4w3N4mWxIiT3QILDJDUQayPqm2e8Q8NUa0RSUkGCfe33AfjR3Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/connect/node_modules/raw-body": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz",
-      "integrity": "sha512-BDwZAZe9kLUnOYUI5P//8Jc7HFoKTDaeLGFuoo9cmPhhzSXvIVovcsbuQT0wWtGBMMwEgME0CRQYRU6yUa5xQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~0.3.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/connect/node_modules/send": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
-      "integrity": "sha512-FPyeqtit9Z3zbusjv0KQyR8vQ9CL57qPNOz4GgcuIPSk+nx9WTUIMQoR6+0a7YOZpQVTtk04qH0IVQG3rohZ0Q==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "0.2.1",
-        "debug": "0.8.0",
-        "fresh": "~0.2.1",
-        "mime": "1.2.11",
-        "range-parser": "~1.0.0"
-      }
-    },
-    "node_modules/connect/node_modules/send/node_modules/debug": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz",
-      "integrity": "sha512-jR+JRuwlhTwNPpLU6/JhiMydD6+GnL/33WE8LlmnBUqPHXkEpG2iNargYBO/Wxx7wXn7oxU6XwYIZyH4YuSW9Q==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/connect/node_modules/serve-index": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz",
-      "integrity": "sha512-BCHuQ0kX88zfvldEMc8k+niVq/jX2T4IbYyGBMmzV225+NcPeI+EPTtISxFxJnAZzIip1xWbE9J0dhZ2cCNFIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "batch": "0.5.0",
-        "negotiator": "0.4.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/connect/node_modules/serve-index/node_modules/negotiator": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz",
-      "integrity": "sha512-pJQhDYP0X6G8E8+BvYHyBd0K1qLE09MPWc5wm5+zeX9mx7vJ+VoQcE65VN1C0+RXnnmneTwGCcUxqhSWvyShow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/connect/node_modules/serve-static": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
-      "integrity": "sha512-vzgWiHz5xrM19pqugiYI6sWP9B0+K6vz4Ep5G1my9lVhuYkRXGYs5xtnXZ06fpLPRumROSZ1CLqiRxdngPkojQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parseurl": "1.0.1",
-        "send": "0.3.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/content-disposition": {
@@ -1566,34 +1291,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz",
-      "integrity": "sha512-IDZgX9fLt2jBmlUQdLIp7oH3RdNq/kYH5JDKY6+gWNemY5SJVTMJk+ZKfjfHgJBc+h9dppDAocUxOP94dDH2Iw==",
-      "dev": true,
-      "dependencies": {
-        "cookie": "0.1.0",
-        "cookie-signature": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-      "integrity": "sha512-YSNOBX085/nzHvrTLEHYHoNdkvpLU1MPjU3r1IGawudZJjfuqnRNIFrcOJJ7bfwC+HWbHL1Y4yMkC0O+HWjV7w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie-signature": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
-      "integrity": "sha512-/KzKzsm0OlguYov01OlOpTkX5MhBKUmfL/KMum7R80rPKheb9AwUzr78TwtBt1OdbnWrt4X+wxbTfcQ3noZqHw==",
-      "dev": true
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -1641,17 +1338,6 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/csurf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz",
-      "integrity": "sha512-HMuTYeiAFjKTvJ8Hssw0N/m8TYks3+UKZg9k0ypp1/s6KoxjIiuDFIB6yXggcu5Dev6fu1uNJGb3Qy6ok+wtzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "scmp": "~0.0.3",
-        "uid2": "~0.0.2"
       }
     },
     "node_modules/debug": {
@@ -1813,23 +1499,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/envify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-1.2.1.tgz",
-      "integrity": "sha512-iShXdC8O/5jo8hPIh65Y1M28YkxW4cqPw3/mg4g5q4RQbMUljOeWp2Ctno4S1ZyTUyoGrioGAZu2t9kP79wp0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "esprima-fb": "~3001.1.0-dev-harmony-fb",
-        "jstransform": "~3.0.0",
-        "through": "~2.3.4",
-        "xtend": "~2.1.2"
-      },
-      "bin": {
-        "envify": "bin/envify"
-      }
-    },
     "node_modules/envinfo": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
@@ -1842,13 +1511,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/errorhandler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.0.tgz",
-      "integrity": "sha512-Hzy+KyeSeZVOJEe+SbsMqPYxKRq7B1cA2b/l1ErPoliKX3RGUJ01YM0aIhFeHf+XNW71VwYWyrfoGv+Omxqf+w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -1880,15 +1542,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/es5-ext": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-      "integrity": "sha512-wP3OSxZ0L/qK76t6qxPR8gWr2o5F4SzNF9qS5F/mOfVY3Ezcg07v6hSkETDmoekXIzn8xhQbHpp+tVlOE+qOAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1918,20 +1571,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/esprima-fb": {
-      "version": "3001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-      "integrity": "sha512-a3RFiCVBiy8KdO6q/C+8BQiP/sRk8XshBU3QHHDP8tNzjYwR3FKBOImu+PXfVhPoZL0JKtJLBAOWlDMCCFY8SQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/esrecurse": {
@@ -1984,18 +1623,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-      "integrity": "sha512-kdjfxF6jYJ5m/OEe3ZNNJzbCEcagF4lNJeuhgrBSRnlitpdxICDKzCel+Z5Wbl7K9UhBN/7k2MzXBvCvSwfzzg==",
-      "dev": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/eventemitter3": {
@@ -2056,60 +1683,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-session": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.0.2.tgz",
-      "integrity": "sha512-2/FkTBWDEM5jPk6GDq079QWiGwuwp+4gTwqXYWbVkyKa/km9uPHciBRHs52WCtngQ09W2J7WuCj5cYek6hMM3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "0.2.1",
-        "cookie": "0.1.0",
-        "cookie-signature": "1.0.3",
-        "debug": "0.7.4",
-        "uid2": "0.0.3",
-        "utils-merge": "1.0.0"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-      "integrity": "sha512-YSNOBX085/nzHvrTLEHYHoNdkvpLU1MPjU3r1IGawudZJjfuqnRNIFrcOJJ7bfwC+HWbHL1Y4yMkC0O+HWjV7w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie-signature": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
-      "integrity": "sha512-/KzKzsm0OlguYov01OlOpTkX5MhBKUmfL/KMum7R80rPKheb9AwUzr78TwtBt1OdbnWrt4X+wxbTfcQ3noZqHw==",
-      "dev": true
-    },
-    "node_modules/express-session/node_modules/debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-      "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/express-session/node_modules/uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
-      "dev": true
-    },
-    "node_modules/express-session/node_modules/utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha512-HwU9SLQEtyo+0uoKXd1nkLqigUWLB+QuNQR4OcmB73eWqksM5ovuqcycks2x043W8XVb75rG1HQ0h93TMXkzQQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2342,25 +1915,6 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/handlebars": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
-      "integrity": "sha512-OdfkaA0M8qGD5EJBkMw3TpguSWl6lz94jdyVmYs5e4TpwepZJ35Y5XlchsIwcN7NP/yzNa3MJYd/dRTO7Nf/fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "optimist": "~0.3"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "~2.3"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2896,28 +2450,6 @@
         "jsonrepair": "bin/cli.js"
       }
     },
-    "node_modules/jstransform": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
-      "integrity": "sha512-sMwqW0EdQk2A5NjddlcSSLp6t7pIknOrJtxPU3kMN82RJXPGbdC3fcM5VhIsApNKL1hpeH38iSQsJRbgprPQZg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "base62": "0.1.1",
-        "esprima-fb": "~3001.1.0-dev-harmony-fb",
-        "source-map": "0.1.31"
-      },
-      "engines": {
-        "node": ">=0.8.8"
-      }
-    },
-    "node_modules/keypress": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-      "integrity": "sha512-x0yf9PL/nx9Nw9oLL8ZVErFAk85/lslwEP7Vz7s5SI1ODXZIgit3C5qyWjw4DxOuO/3Hb4866SQh28a1V1d+WA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2967,17 +2499,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==",
-      "dev": true,
-      "engines": [
-        "node",
-        "rhino"
-      ],
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -3036,21 +2557,6 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
-    "node_modules/memoizee": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-      "integrity": "sha512-0VZI0btwyGk6FSDnJGuJtso4M/eSxhVb5ID5AZNWMFFgT2LexCV18hHI764V4ELKlyfnQ5KMQ+q5H3uvFN3MLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es5-ext": "~0.9.2",
-        "event-emitter": "~0.2.2",
-        "next-tick": "0.1.x"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -3067,16 +2573,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/method-override": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz",
-      "integrity": "sha512-tRFPvCWAvdTvrir2QsY24OTE9jSPs5FyRu85hAvQUhQZBzUimc7ZrD8caeZSpT3h0oyyNmb1HyJ8yUYZ5wx+mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "methods": "*"
-      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -3145,33 +2641,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/mkdirp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.4.0.tgz",
-      "integrity": "sha512-l4/GdhkYnvcQxztcZecGWmF2TYbk6R52LS75hV0bzpZA+pvEJfeVtJrOU1hUFFZT9GihgEcFc65zmP2ZtNRtSg==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/morgan": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.0.0.tgz",
-      "integrity": "sha512-k9QzPEjwMIi8fKmY5LB3sQNk3J7yo7ERjxDrE6Aj2o6Wg/o/ZFU+zw5WNxz5X0jH6cWUzMY37bFMvvWEXanjeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~0.2.0"
-      }
-    },
-    "node_modules/morgan/node_modules/bytes": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
-      "integrity": "sha512-odbk8/wGazOuC1v8v4phoV285/yx8UN5kfQhhuxaVcceig4OUiCZQBtaEtmA1Q78QSTN9iXOQ7X2EViybrEvtQ==",
-      "dev": true
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3192,47 +2661,6 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
-    },
-    "node_modules/multiparty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
-      "integrity": "sha512-fiFMI4tSze1TsrWFZNABRwy7kF/VycEWz4t0UFESOoP5IdJh29AUFmbirWXv/Ih/rNw62OO2YaQpQEiw1BFQpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.1.9",
-        "stream-counter": "~0.2.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/multiparty/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/multiparty/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/multiparty/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
@@ -3256,16 +2684,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-tick": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-      "integrity": "sha512-I44QWeGCHJTx2D3buhnljvSjmPgJua3zdPGtlCQEvA45t9kS/CaHnlVqidTzHwq8LGXhD2SMezjk4hQgP+32Lg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -3306,14 +2724,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -3362,16 +2772,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "dev": true,
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
       }
     },
     "node_modules/p-limit": {
@@ -3474,12 +2874,6 @@
       "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
-      "dev": true
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
@@ -3628,19 +3022,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/react": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.9.0.tgz",
-      "integrity": "sha512-mHYOa7IlZigybJN9Fek64QZmn6aVLeYDEIWoOIW/jrMjlmg422Eh9/OaHm5BVrK5Bh4+F2bonnZvEB5fcfmGpA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "envify": "~1.2.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3725,13 +3106,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/response-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz",
-      "integrity": "sha512-P06PnmA5uf50GduVOPGtebV8J4Vcdv7G8bzX4AH0ezhzlN1xJxuYmc4BoFDa0NWu83gPwHcAjdOL3TFmYPvzWg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -3836,14 +3210,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/scmp": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz",
-      "integrity": "sha512-ya4sPuUOfcrJnfC+OUqTFgFVBEMOXMS1Xopn0wwIhxKwD4eveTwJoIUN9u1QHJ47nL29/m545dV8KqI92MlHPw==",
-      "deprecated": "scmp v2 uses improved core crypto comparison since Node v6.6.0",
-      "dev": true,
-      "license": "BSD"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -4021,13 +3387,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.1.tgz",
-      "integrity": "sha512-MhLr9kgQwqnNHUEIdUhcCFRm7TU/A152bPELdvqDnEBqBhqbEhFqW9LFj5HFExhiQMlsYLSIDwMjh3Sr+8xDMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -4120,18 +3479,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-      "integrity": "sha512-qFALUiKHo35Duky0Ubmb5YKj9b3c6CcgGNGeI60sd6Nn3KaY7h9fclEOcCVk0hwszwYYP6+X2/jpS5hHqqVuig==",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/source-map-js": {
@@ -4246,16 +3593,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/static-favicon": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/static-favicon/-/static-favicon-1.0.2.tgz",
-      "integrity": "sha512-462dn/fhYwu7CWtOK+B3KAn6iFA2nlwfhM72Qkgm4HIGe3UAJ1BSJs3M9RIufQ2SrTmruzxB0ZCGHo5N7+lNpA==",
-      "deprecated": "use serve-favicon module",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4265,46 +3602,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/stream-counter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-      "integrity": "sha512-GjA2zKc2iXUUKRcOxXQmhEx0Ev3XHJ6c8yWGqhQjWwhGrqNwSsvq9YlRLgoGtZ5Kx2Ln94IedaqJ5GUG6aBbxA==",
-      "dev": true,
-      "license": "BSD",
-      "dependencies": {
-        "readable-stream": "~1.1.8"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/stream-counter/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stream-counter/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/stream-counter/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4453,14 +3750,6 @@
         "tslib": "^2"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -4528,31 +3817,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/uglify-js": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-      "integrity": "sha512-T2LWWydxf5+Btpb0S/Gg/yKFmYjnX9jtQ4mdN9YRq73BhN21EhU0Dvw3wYDLqd3TooGUJlCKf3Gfyjjy/RTcWA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "async": "~0.2.6",
-        "optimist": "~0.3.5",
-        "source-map": "~0.1.7"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/uid2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
-      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
@@ -4692,13 +3956,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/vhost": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz",
-      "integrity": "sha512-j5oZxSO2DUNZfdQBZlNrxLAGDg1BEgT7njN73f9XDldKoNzv00zeyhgUY5jR70G6kdTrF0xOzESQnnvaJ/Td4g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
@@ -5049,139 +4306,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/webpack-server": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/webpack-server/-/webpack-server-0.1.2.tgz",
-      "integrity": "sha512-33Jd/VIMV5YAb9ZseXqphNcum03RUE4tdFumsDRMpmOqrbCIhg8jA2Q+KsNNOPwJYAkJbpOr/cbe7P8aLqfslg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-color": "~0.2.3",
-        "express": "~3.5.0",
-        "handlebars": "~2.0.0-alpha.2",
-        "lodash": "~2.4.1"
-      },
-      "peerDependencies": {
-        "react": "~0.9"
-      }
-    },
-    "node_modules/webpack-server/node_modules/commander": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
-      "integrity": "sha512-uoVVA5dchmxZeTMv2Qsd0vhn/RebJYsWo4all1qtrUL3BBhQFn4AQDF4PL+ZvOeK7gczXKEZaSCyMDMwFBlpBg==",
-      "dev": true,
-      "dependencies": {
-        "keypress": "0.1.x"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
-    },
-    "node_modules/webpack-server/node_modules/cookie": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-      "integrity": "sha512-+mHmWbhevLwkiBf7QcbZXHr0v4ZQQ/OgHk3fsQHrsMMiGzuvAmU/YMUR+ZfrO/BLAGIWFfx2Z7Oyso0tZR/wiA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/webpack-server/node_modules/cookie-signature": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
-      "integrity": "sha512-/KzKzsm0OlguYov01OlOpTkX5MhBKUmfL/KMum7R80rPKheb9AwUzr78TwtBt1OdbnWrt4X+wxbTfcQ3noZqHw==",
-      "dev": true
-    },
-    "node_modules/webpack-server/node_modules/debug": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-      "integrity": "sha512-HlXEJm99YsRjLJ8xmuz0Lq8YUwrv7hAJkTEr6/Em3sUlSUNl0UdFA+1SrY4fnykeq1FVkUEUtwRGHs9VvlYbGA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/webpack-server/node_modules/express": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-3.5.3.tgz",
-      "integrity": "sha512-48nmJguLFuSN/bzWQiXMVPbVpPHj/kc7lL02+w2Y8OYfS2ebx0r48zkLzU9bGNlO6NHR/BPHZrIGnurGiFeD3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "0.2.1",
-        "commander": "1.3.2",
-        "connect": "2.14.5",
-        "cookie": "0.1.2",
-        "cookie-signature": "1.0.3",
-        "debug": ">= 0.7.3 < 1",
-        "fresh": "0.2.2",
-        "merge-descriptors": "0.0.2",
-        "methods": "0.1.0",
-        "mkdirp": "0.4.0",
-        "range-parser": "1.0.0",
-        "send": "0.3.0"
-      },
-      "bin": {
-        "express": "bin/express"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/webpack-server/node_modules/fresh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
-      "integrity": "sha512-ZGGi8GROK//ijm2gB33sUuN9TjN1tC/dvG4Bt4j6IWrVGpMmudUBCxx+Ir7qePsdREfkpQC4FL8W0jeSOsgv1w==",
-      "dev": true
-    },
-    "node_modules/webpack-server/node_modules/merge-descriptors": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
-      "integrity": "sha512-dYBT4Ep+t/qnPeJcnMymmhTdd4g8/hn48ciaDqLAkfRf8abzLPS6Rb6EBdz5CZCL8tzZuI5ps9MhGQGxk+EuKg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack-server/node_modules/methods": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
-      "integrity": "sha512-N4cn4CbDqu7Fp3AT4z3AsO19calgczhsmCGzXLCiUOrWg9sjb1B+yKFKOrnnPGKKvjyJBmw+k6b3adFN2LbuBw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack-server/node_modules/mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha512-Ysa2F/nqTNGHhhm9MV8ure4+Hc+Y8AWiqUdHxsO7xu8zc92ND9f3kpALHjaP026Ft17UfxrMt95c50PLUeynBw==",
-      "dev": true
-    },
-    "node_modules/webpack-server/node_modules/range-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
-      "integrity": "sha512-wOH5LIH2ZHo0P7/bwkR+aNbJ+kv3CHVX4B8qs9GqbtY29fi1bGPV5xczrutN20G+Z4XhRqRMTW3q0S4iyJJPfw==",
-      "dev": true
-    },
-    "node_modules/webpack-server/node_modules/send": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
-      "integrity": "sha512-FPyeqtit9Z3zbusjv0KQyR8vQ9CL57qPNOz4GgcuIPSk+nx9WTUIMQoR6+0a7YOZpQVTtk04qH0IVQG3rohZ0Q==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "0.2.1",
-        "debug": "0.8.0",
-        "fresh": "~0.2.1",
-        "mime": "1.2.11",
-        "range-parser": "~1.0.0"
-      }
-    },
-    "node_modules/webpack-server/node_modules/send/node_modules/debug": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz",
-      "integrity": "sha512-jR+JRuwlhTwNPpLU6/JhiMydD6+GnL/33WE8LlmnBUqPHXkEpG2iNargYBO/Wxx7wXn7oxU6XwYIZyH4YuSW9Q==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -5240,16 +4364,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -5270,19 +4384,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4",
-    "webpack-server": "^0.1.2"
+    "webpack-dev-server": "^5.0.4"
   }
 }


### PR DESCRIPTION
Dependabot raised several crticial security flags for dependencies related to webpack-server. This package is very old.
I don't think it was intentionally included with this project. It doesn't appear to be necessary.

This should resolve critical-level security issues with these webpack-server dependencies:
- handlebars
- lodash
- morgan
- uglify-js

And likely others.