### PR TITLE
Fix: JSON Editor doesn't scroll to selections

### DIFF
--- a/src/components/RightMenu/EditorAndHelpMenu.tsx
+++ b/src/components/RightMenu/EditorAndHelpMenu.tsx
@@ -102,7 +102,7 @@ const EditorAndHelpMenu: React.FC<EditorAndHelpMenuProps> = ({
                     <div className={`info-menu ${activeTab === TABS.FILE ? "" : "hidden"}`}>
                         <FileTab model={modelJSON} setModel={setModelJSON} selectedDiagramIndex={selectedDiagramIndex} setSelectedDiagramIndex={setSelectedDiagramIndex} selectedRunnableModelIndices={selectedRunnableModelIndices} setSelectedRunnableModelIndices={setSelectedRunnableModelIndices} apiInstance={apiInstance} setApiInstance={setApiInstance} />
                     </div>
-                    <div className={`${activeTab === TABS.JSON ? "" : "hidden"}`}>
+                    <div className={`info-menu-json ${activeTab === TABS.JSON ? "" : "hidden"}`}>
                         <VanillaJSONEditor
                             content={content}
                             onChange={(newContent: any, _previousContent, { contentErrors, patchResult: _ }) => {

--- a/src/index.css
+++ b/src/index.css
@@ -302,6 +302,11 @@ body {
     height: 100%;
 }
 
+.info-menu-json {
+    height: 100%;
+    overflow-y: auto;
+}
+
 /* Currently for right-side menu items that are not selected */
 .hidden {
     display: none !important;


### PR DESCRIPTION
Fixes #68

See that issue's discussion thread for my analysis and conclusions.

Fixed an issue where the JSON editor was no longer scrolling to any content selections.  
This had the knock-on effect of hiding the editor's top ribbon and bottom info displays if the user was scrolled partway through the JSON content.  
All of this is now fixed!

- Added a style class name for the `<div>` that holds the JSON editor
- This style class now limits the editor's height to the height of its parent `<div>` and uses an `auto` overflow rule for the JSON content, which is what the JSON editor needs in order to be able to control its own scroll position