### PR TITLE
Add new API Call evaluatable asset

### DIFF
--- a/src/components/Diagram/CausalDecisionDiagram.tsx
+++ b/src/components/Diagram/CausalDecisionDiagram.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import Xarrow, { useXarrow, Xwrapper } from "react-xarrows";
 import DiagramElement from "./DiagramElement";
-import { evaluateModel } from "../../lib/Diagram/evaluateModel"
+import { CachedAPIResult, evaluateModel } from "../../lib/Diagram/evaluateModel"
 import { getIODataMap, getFunctionMap, getControlsMap, getDiagramElementMap, getDiaElemAssociatedDepsMap, getEvaluatableAssetMap } from "../../lib/modelPreprocessing";
 import { causalTypeColors } from "../../lib/Diagram/cddTypes";
 import { getExpandedPathsForSelectedDiagramElements } from "../../lib/rightMenu/JSONEditorPathExpansion";
@@ -51,6 +51,14 @@ const CausalDecisionDiagram: React.FC<CausalDecisionDiagramProps> = ({
     //Evaluatable Assets: Import functions from their Base64-encoded string values
     const functionMap = useMemo(() => getFunctionMap(model), [model]);
 
+    // Cache API Call results here, so the model doesn't absolutely spam all of its APIs all the time
+    // Key: UUID of the Eval Element that triggers the API call
+    // Value: Array of API Cache Results, which include the full URI for the call, a stringified version of the request body JSON, and
+    // a stringified version of the result JSON
+    // Each Evaluatable Element keeps one cached result for now.. This map might get huge if you have a lot
+    // of API stuff going on
+    const [apiCache, setAPICache] = useState<Map<string, Array<CachedAPIResult>>>(new Map());
+
     //InitialIOValues is IMMUTABLE.
     //Used to check whether incoming model JSON has an edited IO values list.
     //We can't let React check this itself because it just checks refs. This is a value comparison.
@@ -70,6 +78,7 @@ const CausalDecisionDiagram: React.FC<CausalDecisionDiagramProps> = ({
         {
             setInitialIOValues(incomingIOMap);
             setIOValues(incomingIOMap);
+            setAPICache(new Map());
         }
         else
         {
@@ -99,7 +108,7 @@ const CausalDecisionDiagram: React.FC<CausalDecisionDiagramProps> = ({
 
         const runEvaluation = async () => {
             const result = await evaluateModel(
-                model, functionMap, evalAssetMap, IOValues, selectedRunnableModelIndices
+                model, functionMap, evalAssetMap, IOValues, apiCache, setAPICache, selectedRunnableModelIndices
             );
 
             if (!componentHasBeenUnmounted)

--- a/src/components/Diagram/Displays/displayTypes/ControlSelector.tsx
+++ b/src/components/Diagram/Displays/displayTypes/ControlSelector.tsx
@@ -54,11 +54,6 @@ const ControlSelector: React.FC<CommonDisplayProps> = ({
         [0]
     );
 
-    if(Array.isArray(optionValues) && !optionValues.includes(selectedValue) && optionValues.length > 0)
-    {
-        setSingleValue(optionValues[0]);
-    }
-
     const selectedIdx = Math.max(0, optionValues.indexOf(selectedValue));
 
     let optionIdx = 0;

--- a/src/components/Diagram/Displays/displayTypes/ControlText.tsx
+++ b/src/components/Diagram/Displays/displayTypes/ControlText.tsx
@@ -37,7 +37,7 @@ const ControlText: React.FC<CommonDisplayProps> = ({
     // This display labels itself with its name
     const label = displayJSON.meta.name ?? "";
 
-    const textValue = (
+    const textValue = String(
         computedIOValues.get(String(displayIOValuesList[0])) ??
         displayJSON.content.controlParameters?.value ??
         ""

--- a/src/components/Diagram/Displays/displayTypes/DisplayBarChart.tsx
+++ b/src/components/Diagram/Displays/displayTypes/DisplayBarChart.tsx
@@ -59,9 +59,9 @@ const DisplayBarChart: React.FC<CommonDisplayProps> = ({
                 width={width}
                 height={200}
                 data={data}
-                minY={displayJSON.content.minY}
-                maxY={displayJSON.content.maxY}
-                stepHeight={displayJSON.content.stepHeight ?? 1}
+                minY={data.minY ?? displayJSON.content.minY} //This is sneaky, but we can also provide min/max via data object
+                maxY={data.maxY ?? displayJSON.content.maxY}
+                stepHeight={data.stepHeight ?? displayJSON.content.stepHeight ?? 1}
             />
         </div>
     )

--- a/src/components/RunnableEditor/RunnableModel.tsx
+++ b/src/components/RunnableEditor/RunnableModel.tsx
@@ -135,6 +135,9 @@ const RunnableModel: React.FC<RunnableModelProps> = ({
 
 
     const evalElementsList = thisModel.elements.map((runnableElement: any) => {
+
+        const elementAssetType = evalAssetMap.get(runnableElement.evaluatableAsset)?.evalType ?? ""
+
         return (
             <div className="eval-element-info">
                 <h3>{cleanComponentDisplay(runnableElement.meta, "Element")} <button className="json-link" onClick={() => expandNonIOComponentInJSON(getExpandedPathForEvaluatableElement(runnableElement.meta?.uuid, model))}>(Reveal in JSON)</button></h3>
@@ -142,12 +145,20 @@ const RunnableModel: React.FC<RunnableModelProps> = ({
                     <p>
                         <b>Evaluatable Asset Used: </b>{generateEvalAssetsOptionsForElement(runnableElement.meta.uuid, runnableElement.evaluatableAsset)}
                     </p>
-                    <p>
-                        <b>Function: </b>{generateFunctionNameOptionsForElement(runnableElement.meta.uuid, runnableElement.evaluatableAsset, runnableElement.functionName)}
-                    </p>
+                    {elementAssetType == "Script" && (
+                        <p>
+                            <b>Function: </b>{generateFunctionNameOptionsForElement(runnableElement.meta.uuid, runnableElement.evaluatableAsset, runnableElement.functionName)}
+                        </p>
+                    )}
+                    {elementAssetType == "APICall" && (
+                        <p>
+                            <b>Endpoint URI: </b>{evalAssetMap.get(runnableElement.evaluatableAsset)?.content?.endpointURI ?? "(none)"}
+                        </p>
+                    )}
                     {runnableElement.meta.summary && (<div className="eval-element-summary">
                         <ReactMarkdown children={runnableElement.meta.summary}/>
                     </div>)}
+
                 </div>
                 <div className="eval-io">
                     <div className="eval-io-list">

--- a/src/components/RunnableEditor/RunnableModelEditor.css
+++ b/src/components/RunnableEditor/RunnableModelEditor.css
@@ -74,6 +74,7 @@
         .model-options-list {
             overflow-y: auto;
             border: var(--runnable-editor-border);
+            min-height: 6em;
 
             .model-option {
                 padding-top: 0px;

--- a/src/components/RunnableEditor/RunnableModelEditor.tsx
+++ b/src/components/RunnableEditor/RunnableModelEditor.tsx
@@ -6,7 +6,7 @@ import ReactMarkdown from "react-markdown";
 
 import Editor from "@monaco-editor/react"
 import { getActiveIOValues, getEvaluatableAssetMap, getIOMap } from "../../lib/modelPreprocessing";
-import { addControlToModel, addDisplayToControl, addIOsToControl, addIOToModel, addScriptToModel, deleteControl, deleteDisplayFromControl, deleteEvaluatableAssetFromModel, deleteIOFromModel, moveIOsInControl, removeIOsFromControl, updateScript } from "../../lib/RunnableModelEditor/runnableCRUD";
+import { addAPICallToModel, addControlToModel, addDisplayToControl, addIOsToControl, addIOToModel, addScriptToModel, deleteControl, deleteDisplayFromControl, deleteEvaluatableAssetFromModel, deleteIOFromModel, moveIOsInControl, removeIOsFromControl, updateScript } from "../../lib/RunnableModelEditor/runnableCRUD";
 import { undefinedIOJSON } from "../../lib/defaultJSON";
 import { getExpandedPathForControl, getExpandedPathForEvaluatableAsset, getExpandedPathsForSelectedIOValues } from "../../lib/rightMenu/JSONEditorPathExpansion";
 import { RIGHT_MENU_TABS } from "../../lib/rightMenu/menuTabIDs";
@@ -160,21 +160,26 @@ const RunnableModelEditor: React.FC<RunnableModelEditorProps> = ({
                 setEditorCode(atob(evalAsset.content.script));
                 setEditorEvalAssetUUID(evalAsset.meta.uuid);
             }
+            const evalType = evalAsset.evalType ?? "Unknown";
             return (
                 <div key={evalAsset.meta.uuid} className="eval-asset-info">
                     <h3>{cleanComponentDisplay(evalAsset.meta, "Evaluatable Asset")} <button className="json-link" onClick={() => expandNonIOComponentInJSON(getExpandedPathForEvaluatableAsset(evalAsset.meta?.uuid, model))}>(Reveal in JSON)</button></h3>
-                    <p><b>Type: </b>{evalAsset.evalType}</p>
+                    <p><b>Type: </b>{evalType}</p>
                     {evalAsset.meta.summary && <ReactMarkdown children={evalAsset.meta.summary}/>}
+                    {(evalType == "APICall" && <>
+                        <p><b>URI: </b>{evalAsset.content.endpointURI}</p>
+                        <p><b>Method: </b>{evalAsset.content.restMethod}</p>
+                    </>)}
                     <div>
-                        <button
+                        {(evalType == "Script" && <button
                             onClick={openEditor}
                         >
-                            {`Edit ${evalAsset.evalType}`}
-                        </button>
+                            {`Edit ${evalType}`}
+                        </button>)}
                         <button
                             onClick={() => setModel(deleteEvaluatableAssetFromModel(model, evalAsset.meta))}
                         >
-                            {`Delete ${evalAsset.evalType}`}
+                            {`Delete ${evalType}`}
                         </button>
                     </div>
                 </div>
@@ -402,6 +407,11 @@ const RunnableModelEditor: React.FC<RunnableModelEditorProps> = ({
                             onClick={() => setModel(addScriptToModel(model))}
                         >
                             Add New Script
+                        </button>
+                        <button
+                            onClick={() => setModel(addAPICallToModel(model))}
+                        >
+                            Add New API Call
                         </button>
                     </div>
                 </div>

--- a/src/lib/Diagram/evaluateModel.tsx
+++ b/src/lib/Diagram/evaluateModel.tsx
@@ -1,4 +1,16 @@
 /**
+ * Holds info about the results of a specific element's evaluation.
+ * @member succeeded Flag for whether the element is considered "successfully evaluated" or not
+ * @member newWorkingIOMap Updated version of the model's map of computed I/O values, after evaluating the element
+ * @member populatedIOValues List of I/O value UUIDs that were populated by this element's evaluation output. This will now be considered "known" I/O values
+ */
+type EvaluationResults = {
+    succeeded: boolean,
+    newWorkingIOMap: Map<string, any>,
+    populatedIOValues: Set<string>
+}
+
+/**
  * Evaluates a runnable model within the given model.
  * Performs one step of simulation for the decision. Feeds I/O Values from ioMap into their associated
  * functions in funcMap, and stores outputs in a fresh copy of ioMap, returned at the end of the sim step.
@@ -12,7 +24,7 @@
  * @param debugLogs Flag for whether to log lots of debug stuff to console
  * @returns A fresh copy of ioMap, with I/O values updated based on the results of one step of the decision simulation
  */
-export function evaluateModel(model: any, funcMap: Map<string, Function>, ioMap: Map<string, any>, activeRunnableModels = [0], debugLogs = false): Map<string, any> {
+export async function evaluateModel(model: any, funcMap: Map<string, Function>, evalAssetMap: Map<string, any>, ioMap: Map<string, any>, activeRunnableModels = [0], debugLogs = true): Promise<Map<string, any>> {
     if(debugLogs) console.log("Eval start.");
 
     //Handle case where there's nothing to evaluate (Return a copy of IO Map unedited)
@@ -53,7 +65,7 @@ export function evaluateModel(model: any, funcMap: Map<string, Function>, ioMap:
     let knownIOValues = new Set<string>(Array.from(ioMap.keys()).filter((IOValUUID: string) => !outputValues.has(IOValUUID)))
 
     //Avoid immutable changes to the original I/O map to preserve initial simulation state.
-    const workingIOMap = new Map(ioMap);
+    let workingIOMap = new Map(ioMap);
 
     //Evaluation will continue until we either run out of unevaluated elements
     //OR we fail to remove any elements from the unevaluated list in an iteration
@@ -69,9 +81,10 @@ export function evaluateModel(model: any, funcMap: Map<string, Function>, ioMap:
 
         //Try to evaluate unevaluated elements. If successful, remove them from unevaluated list.
         let toRemoveFromUnevaluated = new Set<string>();
-        unevaluated.forEach((uuid: string) => {
+        for (const uuid of unevaluated) {
             const evalElem = evals.get(uuid);
             const evalInputs = evalElem.inputs.map((uuid: string) => workingIOMap.get(uuid));
+            const evalAsset = evalAssetMap.get(evalElem.evaluatableAsset ?? "");
 
             //This element can be evaluated if we have a known value for all of its requested inputs
             const isReadyToEval = evalElem.inputs.every((inputUUID: string) => knownIOValues.has(inputUUID));
@@ -79,30 +92,28 @@ export function evaluateModel(model: any, funcMap: Map<string, Function>, ioMap:
             {
                 if(debugLogs) console.log("Evaluating ", uuid, " - Populated IO Values: ", knownIOValues);
 
-                try
+                //EVALUATE THE ELEMENT
+                let evalResults: EvaluationResults;
+                switch(evalAsset.evalType) {
+                    case "Script":
+                        evalResults = evaluateScriptElement(evalElem, evalInputs, funcMap, workingIOMap);
+                        break;
+                    case "APICall":
+                        evalResults = await evaluateAPICallElement(evalElem, evalInputs, evalAsset, workingIOMap);
+                        break;
+                    default:
+                        evalResults = {succeeded: false, newWorkingIOMap: workingIOMap, populatedIOValues: new Set()};
+                }
+                
+                //UPDATE STATE BASED ON RESULTS
+                workingIOMap = evalResults.newWorkingIOMap;
+                knownIOValues = new Set([...knownIOValues, ...evalResults.populatedIOValues]);
+                if (evalResults.succeeded)
                 {
-                    //Get the function from our function map and run it to get our new outputs
-                    const evalFunction = funcMap.get(`${evalElem.evaluatableAsset}_${evalElem.functionName}`) ?? (() => {return []})
-                    const evaluatedOutputs = evalFunction(evalInputs)
-
-                    //Function outputs are assumed to be given in the same order as they're listed in the eval element
-                    for(let i = 0; i < evalElem.outputs.length && i < evaluatedOutputs.length; i++) {
-                        workingIOMap.set(evalElem.outputs[i], evaluatedOutputs[i]);
-                        knownIOValues.add(evalElem.outputs[i]);
-                    }
-
-                    //Right now there's no validation step to confirm that an element evaluated successfully.
-                    //It's just assumed successful after we load and run the function.
                     toRemoveFromUnevaluated.add(uuid);
-
-                } catch (error)
-                {
-                    let message = `Error evaluating element ${uuid}:\n`;
-                    message += `Error executing function ${evalElem.functionName} from Evaluatable Asset ${evalElem.evaluatableAsset}:\n`;
-                    console.error(message, error);
                 }
             }
-        })
+        }
 
         unevaluated = unevaluated.filter((unevalUUID: string) => !toRemoveFromUnevaluated.has(unevalUUID)); //Remove the elements that we evaluated this iteration
 
@@ -120,4 +131,117 @@ export function evaluateModel(model: any, funcMap: Map<string, Function>, ioMap:
 
     return workingIOMap;
     
+}
+
+/**
+ * Evaluate an Evaluatable Element that references an Evaluatable Asset with evalType=APICall. Performs the requested API call, at the endpoint created
+ * by combining the EvalAsset's base URI with an optional extension given as an I/O value. Uses another optional I/O value for the request payload.
+ * Reports success/failure and the list of I/O values populated as outputs by the referenced API call.
+ * Also returns the updated working I/O value map for this evaluation run.
+ * @param evalElem Schema-compliant JSON for the evaluatable element to evaluate. This element references an Evaluatable Asset with evalType=APICall
+ * @param evalInputs Array of raw I/O values intended to configure the API request URI and body.
+ * Input [0] (optional) should be a well-formatted JSON request body.
+ * Input [1] (optional) should be an extension for the base URI stored in the Evaluatable Asset. e.g. "/posts/0"
+ * @param evalAsset Schema-compliant JSON for the evaluatable asset used by this element. Used to set up the fetch call for this API request
+ * @param workingIOMap Map from I/O UUID (String) to raw I/O value. Working I/O map keeps updated values populated by the ongoing evaluation round. This function will update it with new output values from the API call
+ * @returns @see EvaluationResults . Eval resuts with info about success status, the updated map of working I/O values, and a (0-1 length) list of I/O values that were populated as outputs by this API call
+ */
+async function evaluateAPICallElement(evalElem: any, evalInputs: any, evalAsset: any, workingIOMap: Map<string, any>): Promise<EvaluationResults>
+{
+    let succeeded = false;
+    const ioMap = new Map(workingIOMap);
+    const populatedIOValues = new Set<string>();
+
+
+    // -- Construct URI and request body --
+
+    // EVAL INPUT ORDER:
+    // [0]: Body JSON
+    // [1]: URI extension (string)
+    const uriExtension: string = evalInputs[1] ?? evalAsset.content?.defaultURIExtension ?? "";
+    const uri: string = (evalAsset.content?.endpointURI ?? "") + uriExtension;
+    const restMethod: string = evalAsset.content?.restMethod ?? "GET";
+    const bodyJSON = JSON.stringify(evalInputs[0] ?? evalAsset.content?.defaultPayload ?? {});
+
+    const request = (restMethod == "GET"
+        ? {
+            method: restMethod
+        }
+        : {
+            method: restMethod,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: bodyJSON
+        });
+
+
+    // -- Actually make the request --
+
+    try {
+        const response = await fetch(uri, request);
+        if(!response.ok)
+        {
+            throw new Error(`HTTP error, status: ${response.status}`);
+        }
+
+        const json = await response.json();
+        if(evalElem.outputs.length > 0)
+        {
+            ioMap.set(evalElem.outputs[0], json),       //Update working I/O map with new output values
+            populatedIOValues.add(evalElem.outputs[0]); //Tell the evaluation function to add these to the list of "known" values
+        }
+
+        //Right now there's no validation step to confirm that an element evaluated successfully.
+        //It's just assumed successful after we get an OK response with no errors thrown.
+        succeeded = true;
+    } catch (error)
+    {
+        let message = `Error evaluating element ${evalElem.uuid ?? "unknown"}:\n`;
+        message += `Error performing API call to ${uri} with method ${restMethod}. Payload:\n${bodyJSON}`;
+        console.error(message, error);
+    }
+
+    return {succeeded, newWorkingIOMap: ioMap, populatedIOValues};
+}
+
+/**
+ * Evaluate an Evaluatable Element that references an Evaluatable Asset with evalType=Script. Runs the referenced script function, passing in evalInputs
+ * and populating output in a copy of the workingIOMap. Reports success/failure and the list of I/O values populated as outputs by the referenced script.
+ * Also returns the updated working I/O value map for this evaluation run.
+ * @param evalElem Schema-compliant JSON for the evaluatable element to evaluate. This element references an Evaluatable Asset with evalType=Script
+ * @param evalInputs Array of raw I/O values intended to be used as inputs for this evaluatable element. These will be passed to the script in the order given in this list
+ * @param funcMap Maps function names (String) to the function implementations themselves (Function). To avoid collisions, function names prepend their eval asset UUID and an underscore
+ * @param workingIOMap Map from I/O UUID (String) to raw I/O value. Working I/O map keeps updated values populated by the ongoing evaluation round. This function will update it with new output values from the script
+ * @returns @see EvaluationResults . Eval results with info about success status, the updated map of working I/O values, and a list of I/O values that were populated as outputs by this script
+ */
+function evaluateScriptElement(evalElem: any, evalInputs: any, funcMap: Map<string, Function>, workingIOMap: Map<string, any>): EvaluationResults
+{
+    let succeeded = false;
+    const ioMap = new Map(workingIOMap);
+    const populatedIOValues = new Set<string>();
+    try
+    {
+        //Get the function from our function map and run it to get our new outputs
+        const evalFunction = funcMap.get(`${evalElem.evaluatableAsset}_${evalElem.functionName}`) ?? (() => {return []})
+        const evaluatedOutputs = evalFunction(evalInputs)
+
+        //Function outputs are assumed to be given in the same order as they're listed in the eval element
+        for(let i = 0; i < evalElem.outputs.length && i < evaluatedOutputs.length; i++) {
+            ioMap.set(evalElem.outputs[i], evaluatedOutputs[i]);    //Update working I/O map with new output values
+            populatedIOValues.add(evalElem.outputs[i]);             //Tell the evaluation function to add these to the list of "known" values
+        }
+
+        //Right now there's no validation step to confirm that an element evaluated successfully.
+        //It's just assumed successful after we load and run the function with no errors thrown.
+        succeeded = true;
+
+    } catch (error)
+    {
+        let message = `Error evaluating element ${evalElem.uuid ?? "unknown"}:\n`;
+        message += `Error executing function ${evalElem.functionName} from Evaluatable Asset ${evalElem.evaluatableAsset}:\n`;
+        console.error(message, error);
+    }
+
+    return {succeeded, newWorkingIOMap: ioMap, populatedIOValues}
 }

--- a/src/lib/Diagram/evaluateModel.tsx
+++ b/src/lib/Diagram/evaluateModel.tsx
@@ -10,6 +10,12 @@ type EvaluationResults = {
     populatedIOValues: Set<string>
 }
 
+export type CachedAPIResult = {
+    fullURI: string,
+    bodyJSON: string,
+    resultJSON: string,
+}
+
 /**
  * Evaluates a runnable model within the given model.
  * Performs one step of simulation for the decision. Feeds I/O Values from ioMap into their associated
@@ -19,12 +25,15 @@ type EvaluationResults = {
  * 
  * @param model Full model JSON. MUST adhere to OpenDI JSON Schema
  * @param funcMap For accessing script functions from model JSON. Maps name of function to the function itself
+ * @param evalAssetMap For API calls, to easily accesss info like URI, default request body, etc.
  * @param ioMap For accessing I/O values from model JSON. Maps I/O Value UUID to the data for that value
+ * @param apiCache Caches the results of API calls, so that repeat calls are much faster
+ * @param setAPICache Allows eval elements to update the API cache
  * @param activeRunnableModels List of indices for the runnable models to evaluate, in the model's runnableModels list
  * @param debugLogs Flag for whether to log lots of debug stuff to console
  * @returns A fresh copy of ioMap, with I/O values updated based on the results of one step of the decision simulation
  */
-export async function evaluateModel(model: any, funcMap: Map<string, Function>, evalAssetMap: Map<string, any>, ioMap: Map<string, any>, activeRunnableModels = [0], debugLogs = true): Promise<Map<string, any>> {
+export async function evaluateModel(model: any, funcMap: Map<string, Function>, evalAssetMap: Map<string, any>, ioMap: Map<string, any>, apiCache: Map<string, Array<CachedAPIResult>>, setAPICache: Function, activeRunnableModels = [0], debugLogs = false): Promise<Map<string, any>> {
     if(debugLogs) console.log("Eval start.");
 
     //Handle case where there's nothing to evaluate (Return a copy of IO Map unedited)
@@ -99,7 +108,7 @@ export async function evaluateModel(model: any, funcMap: Map<string, Function>, 
                         evalResults = evaluateScriptElement(evalElem, evalInputs, funcMap, workingIOMap);
                         break;
                     case "APICall":
-                        evalResults = await evaluateAPICallElement(evalElem, evalInputs, evalAsset, workingIOMap);
+                        evalResults = await evaluateAPICallElement(evalElem, evalInputs, evalAsset, workingIOMap, apiCache, setAPICache);
                         break;
                     default:
                         evalResults = {succeeded: false, newWorkingIOMap: workingIOMap, populatedIOValues: new Set()};
@@ -146,7 +155,7 @@ export async function evaluateModel(model: any, funcMap: Map<string, Function>, 
  * @param workingIOMap Map from I/O UUID (String) to raw I/O value. Working I/O map keeps updated values populated by the ongoing evaluation round. This function will update it with new output values from the API call
  * @returns @see EvaluationResults . Eval resuts with info about success status, the updated map of working I/O values, and a (0-1 length) list of I/O values that were populated as outputs by this API call
  */
-async function evaluateAPICallElement(evalElem: any, evalInputs: any, evalAsset: any, workingIOMap: Map<string, any>): Promise<EvaluationResults>
+async function evaluateAPICallElement(evalElem: any, evalInputs: any, evalAsset: any, workingIOMap: Map<string, any>, apiCache: Map<string, Array<CachedAPIResult>>, setAPICache: Function): Promise<EvaluationResults>
 {
     let succeeded = false;
     const ioMap = new Map(workingIOMap);
@@ -162,6 +171,29 @@ async function evaluateAPICallElement(evalElem: any, evalInputs: any, evalAsset:
     const uri: string = (evalAsset.content?.endpointURI ?? "") + uriExtension;
     const restMethod: string = evalAsset.content?.restMethod ?? "GET";
     const bodyJSON = JSON.stringify(evalInputs[0] ?? evalAsset.content?.defaultPayload ?? {});
+
+    //Check for existing cached results
+    const cachedCalls = structuredClone(apiCache.get(evalElem.meta?.uuid ?? "") ?? new Array<CachedAPIResult>());
+    for (let i = 0; i < cachedCalls.length; i++)
+    {
+        const cachedResult = cachedCalls[i];
+        if(uri == cachedResult.fullURI && bodyJSON == cachedResult.bodyJSON)
+        {
+            ioMap.set(evalElem.outputs[0], JSON.parse(cachedResult.resultJSON)),    //Update working I/O map with new output values
+            populatedIOValues.add(evalElem.outputs[0]);     //Tell the evaluation function to add these to the list of "known" values
+            succeeded = true;
+
+            //Update cache
+            cachedCalls.unshift(cachedCalls.splice(i, 1)[0]); //Move to front
+            setAPICache((prev: Map<string, Array<CachedAPIResult>>) => {
+                let newCache = structuredClone(prev);
+                newCache.set(evalElem.meta.uuid, cachedCalls);
+                return newCache;
+            });
+
+            return {succeeded, newWorkingIOMap: ioMap, populatedIOValues};
+        }
+    }
 
     const request = (restMethod == "GET"
         ? {
@@ -195,6 +227,24 @@ async function evaluateAPICallElement(evalElem: any, evalInputs: any, evalAsset:
         //Right now there's no validation step to confirm that an element evaluated successfully.
         //It's just assumed successful after we get an OK response with no errors thrown.
         succeeded = true;
+
+        //Update cached results
+        const newResult: CachedAPIResult = {fullURI: uri, bodyJSON, resultJSON: JSON.stringify(json)};
+        cachedCalls.unshift(newResult);
+        const maxCacheSize = Number(evalElem.apiCacheSize);
+        if(maxCacheSize > 0)
+        {
+            if (cachedCalls.length > maxCacheSize)
+            {
+                cachedCalls.pop();
+            }
+            setAPICache((prev: Map<string, Array<CachedAPIResult>>) => {
+                let newCache = structuredClone(prev);
+                newCache.set(evalElem.meta.uuid, cachedCalls);
+                return newCache;
+            });
+        }
+
     } catch (error)
     {
         let message = `Error evaluating element ${evalElem.uuid ?? "unknown"}:\n`;

--- a/src/lib/RunnableModelEditor/runnableCRUD.tsx
+++ b/src/lib/RunnableModelEditor/runnableCRUD.tsx
@@ -1,5 +1,5 @@
 import { cleanComponentDisplay } from "../cleanupNames";
-import { defaultControlJSON, defaultEvaluatableElementJSON, defaultInputOutputValueJSON, defaultScriptJSON } from "../defaultJSON";
+import { defaultAPICallJSON, defaultControlJSON, defaultEvaluatableElementJSON, defaultInputOutputValueJSON, defaultScriptJSON } from "../defaultJSON";
 
 /**
  * Pure/immutable: Updates the given IO Value UUID list to add or remove the
@@ -371,6 +371,19 @@ export function addScriptToModel(model: any)
 {
     let workingModel = structuredClone(model);
     workingModel.evaluatableAssets = [...(workingModel.evaluatableAssets ?? []), defaultScriptJSON()];
+    return workingModel;
+}
+
+/**
+ * Pure/immutable: Updates the given model JSON, adding a new API Call Evaluatable Asset to the model
+ * 
+ * @param model Model JSON to modify
+ * @returns Updated model, with the result of the add applied
+ */
+export function addAPICallToModel(model: any)
+{
+    let workingModel = structuredClone(model);
+    workingModel.evaluatableAssets = [...(workingModel.evaluatableAssets ?? []), defaultAPICallJSON()];
     return workingModel;
 }
 

--- a/src/lib/defaultJSON.tsx
+++ b/src/lib/defaultJSON.tsx
@@ -97,7 +97,7 @@ export function defaultControlJSON(
 }
 
 /**
- * Generate schema-compliant JSON for a new evaluatable asset
+ * Generate schema-compliant JSON for a new evaluatable asset of type Script
  * @returns JSON for a new evaluatable asset, prepopulated as a script with the default JavaScript content
  */
 export function defaultScriptJSON(): any
@@ -115,6 +115,27 @@ export function defaultScriptJSON(): any
         content: {
             language: "javascript",
             script: baseScript
+        }
+    }
+}
+
+/**
+ * Generate schema-compliant JSON for a new evaluatable asset of type APICall
+ * @returns JSON for a new evaluatable asset, prepopulated with a basic API call
+ */
+export function defaultAPICallJSON(): any
+{
+    return {
+        meta: {
+            uuid: uuidv4(),
+            name: "New API Call"
+        },
+        evalType: "APICall",
+        content: {
+            endpointURI: "https://jsonplaceholder.typicode.com/posts",
+            restMethod: "GET",
+            defaultPayload: {},
+            defaultURIExtension: ""
         }
     }
 }

--- a/src/lib/defaultJSON.tsx
+++ b/src/lib/defaultJSON.tsx
@@ -61,6 +61,7 @@ export function defaultDiagramElementJSON(
 export function defaultEvaluatableElementJSON(
     evaluatableAsset=uuidv4(),
     functionName="(None)",
+    apiCacheSize=2,
     inputs:string[]=[],
     outputs:string[]=[]
 ): any {
@@ -71,6 +72,7 @@ export function defaultEvaluatableElementJSON(
         },
         evaluatableAsset,
         functionName,
+        apiCacheSize,
         inputs,
         outputs
     }
@@ -123,7 +125,12 @@ export function defaultScriptJSON(): any
  * Generate schema-compliant JSON for a new evaluatable asset of type APICall
  * @returns JSON for a new evaluatable asset, prepopulated with a basic API call
  */
-export function defaultAPICallJSON(): any
+export function defaultAPICallJSON(
+    endpointURI="https://jsonplaceholder.typicode.com/posts",
+    restMethod="GET",
+    defaultPayload={},
+    defaultURIExtension=""
+): any
 {
     return {
         meta: {
@@ -132,10 +139,10 @@ export function defaultAPICallJSON(): any
         },
         evalType: "APICall",
         content: {
-            endpointURI: "https://jsonplaceholder.typicode.com/posts",
-            restMethod: "GET",
-            defaultPayload: {},
-            defaultURIExtension: ""
+            endpointURI,
+            restMethod,
+            defaultPayload,
+            defaultURIExtension
         }
     }
 }

--- a/src/model_json/builtin-examples/Sweet_Potato_Packing.json
+++ b/src/model_json/builtin-examples/Sweet_Potato_Packing.json
@@ -1,0 +1,3869 @@
+{
+    "$schema": "./schemas/Causal-Decision-Model.json",
+    "meta": {
+        "uuid": "6305869e-9127-4add-b39a-8e3b7862a6f5",
+        "name": "Sweet Potato Packing",
+        "summary": "Models a complex, real-world decision that impacts the Sweet Potato value chain.  \nCreation of this model was supported in part by the intramural research program of the U.S. Department of Agriculture, National Institute of Food and Agriculture, Agriculture and Food Research Initiative (AFRI) Data Science for Food and Agriculture program (2022-67021-37137).\n\n## API Note\n**This decision simulation makes API calls using the Google Sheets API.** To allow the simulation to use the API: \n1. Follow the [Google API Instructions for setting up an API key](https://support.google.com/googleapi/answer/6158862).\n2. From the [Google Cloud Console API Library page](https://console.cloud.google.com/apis/library), activate the [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com).\n3. From the [Google Cloud Console's Credentials page](https://console.cloud.google.com/apis/credentials), select your project, then click **show key** on the new API key.\n4. Copy your API key, and paste it into the first textbox under the CONFIG diagram element.  \n(Hide this summary and click the **+** under the *Decision Configuration* element to see the textbox).\n\n## Decision Description\n\nYou run a sweet potato farming operation.  \nYour inventory consists of **8 fields** of sweet potatoes, which are ready for harvest. At harvest time, your facility is given a set of **orders** to fulfill for commercial vendors. Each vendor requests some number of **40lb boxes** of harvested potatoes, and places restrictions on the **size classifications** they want for their order.\n\nYour job is to **fill** the potato orders. You do this by **selecting** certain potato fields to harvest.  \nYour goal is to **maximize profit** by deciding on the best selection and the best sequence for field harvesting.\n\n**Harvest:** When a field is **selected** for harvest, workers begin to pick potatoes from that field at random. If a picked potato is the right size for the current order, it will go into one of the boxes for that order. Otherwise, it will go into a box for **storage**. Workers will continue picking potatoes until the selected field is completely harvested, or the current order is filled.\n\n**Labor costs:** Harvesting potatoes is labor-intensive, and incurs wage\n costs. The more fields you harvest to fill your orders, the more wages \nyou will need to pay!\n\n**Storage:** Potatoes are stored in 40lb boxes, categorized by their size. This means that once a box is in storage, it can easily be used to fill subsequent orders, without incurring the costs associated with field harvesting. However, any boxes left in storage at the end of a day will incur a **per-box storage fee**.\n\n**Field-switching:** Anytime you select more than one field for harvest within a given day, your harvesting operation must spend *time and labor* to switch over to a different field. Field switching incurs a **wage cost** based on how long it takes to switch, as well as a **flat equipment cost** for each switch.\n\n**Revenue:** Each order pays out based on the number of boxes requested. Once you've completely filled an order, it will contribute to your overall revenue. Be careful! **Incomplete orders do not count toward revenue.**\n\n## Diagram Elements\n\nThis section describes each diagram element in detail.\n\n### Levers\n\nEach Lever provides a set of inputs for field selections for a single order.  \nLevers show information about the number of boxes and the size restrictions requested for the current order, and provide 3 dials for field selection. **Click the + icon to expand field selection Dials**.\n\n### Externals\n\nExternals configure the details for each order, including the size restrictions and the number of boxes requested. Make changes to each External to simulate different ordering scenarios.\n\n### CONFIG\n\nTo make further, more complex adjustments to the simulation, edit the values in this special CONFIG element.\n\n### Intermediates\n\nIntermediates show detailed information about the internal status of your farming operation throughout the packing process.\n\n#### Field States\n\nThe Field States Intermediates show stacked bar charts with information about the number and size distribution of the potatoes in each field. *Green* indicates the number and distribution of any remaining un-harvested potatoes in each field. Before any fields have been selected, all bar charts effectively show the initial contents of all the potatoes in each field, sorted by size, in green.\n\nWhen a field is selected for harvesting by a particular order, its Field State bar chart will update to indicate the number and size distribution of potatoes harvested for that particular order, using the same color as the Dials on the Lever for that order. For example, if Order 1 has dark blue dials, and Field 1 is selected for Order 1, then the Field 1 bar chart will update to include dark blue bars indicating the potatoes harvested for Field 1. If any potatoes remain in Field 1 after filling Order 1, those potatoes will be indicated with green bars below the dark blue bars.\n\n#### Storage State\n\nThe Storage State Intermediate shows the number and size distribution of boxes in storage after workers have finished harvesting from the fields selected for the current order. If the selected fields included many potatoes that were incorrectly sized for the current order, the Storage State chart for that order will indicate some new boxes have been stored for potatoes in those size ranges.\n\n#### Boxes Packed\n\nThe Boxes Packed Intermediate indicates your progress toward filling each order. This Intermediate has a Gauge for each order, from 0 to the number of boxes requested for that order. Once the workers have finished harvesting the fields selected for the current order, that order's Gauge will show the number of boxes you've packed for that order. Try to fill these Gauges up! Unfinished orders do not count toward revenue.\n\n### Outcomes\n\nThe Outcome shows information about your overall Costs, Revenue, and your total Profit. The Cost/Revenue Split bar chart shows costs and revenue color-coded so that you can see each order's contribution to each cost category and revenue. Cost categories are as follows:\n- **C. Swi**: Costs incurred from switching fields.\n- **C. Sto**: Costs incurred from boxes left in storage at the end of each day.\n- **C. Wag**: Labor costs incurred by paying wages (for field harvesting and field switching)\n- **Revenue**: Total revenue for each filled order (based on a flat-rate per-box payout)\n",
+        "documentation": {
+            "content": "",
+            "MIMEType": "text/plain"
+        },
+        "version": "0.1",
+        "draft": true,
+        "createdDate": "2025-07-25T18:37:53-04:00"
+    },
+    "diagrams": [
+        {
+            "meta": {
+                "uuid": "0b50612b-d09c-4e87-8854-79d62b03b669",
+                "name": "Field Harvest Selection: 2 Orders, 2 Days",
+                "createdDate": "2025-07-25T18:37:53-04:00"
+            },
+            "elements": [
+                {
+                    "meta": {
+                        "uuid": "7e12015b-2d0f-4bb0-a96d-96fda0f20753",
+                        "name": "Day 1, Order 1"
+                    },
+                    "causalType": "Lever",
+                    "position": {
+                        "x": 240.5,
+                        "y": 139.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "7578c0c2-0fab-43b0-80fc-43310416949e",
+                                "name": "D1O1 Field Selection 1"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#426a8a",
+                                                "end": "#bacede"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "d32da97a-1ecb-4a07-93d9-fb32dd94d529",
+                                "name": "D1O1 Field Selection 2"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#426a8a",
+                                                "end": "#bacede"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "6b31aac7-228d-4487-b4be-f2b63508456d",
+                                "name": "D1O1 Field Selection 3"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#426a8a",
+                                                "end": "#bacede"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "8426bfcd-b066-4451-8eb3-c7b29d2cf142",
+                                "name": "(Info for Day 1, Order 1)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": " ",
+                                    "isInteractive": false
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "bddc72ba-fa51-4cb7-89c0-92c57d962ab9",
+                        "name": "Day 2, Order 2"
+                    },
+                    "causalType": "Lever",
+                    "position": {
+                        "x": 551.5,
+                        "y": 790.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "e9c50169-24c1-43dc-9b61-3fc029d00322",
+                                "name": "D2O2 Field Selection 1"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#5c243b",
+                                                "end": "#cfa5b6"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "d1deed13-8b21-4270-ab5a-1b3ca8cfcb0d",
+                                "name": "D2O2 Field Selection 2"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#5c243b",
+                                                "end": "#cfa5b6"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "d434d075-38ed-4083-b37f-b8d45fd128dc",
+                                "name": "D2O2 Field Selection 3"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#5c243b",
+                                                "end": "#cfa5b6"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "622144cf-2fda-40e3-9a90-a1cd6c61e60b",
+                                "name": "(Info for Day 2, Order 2)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": " ",
+                                    "isInteractive": false
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "0f5e0c26-9c63-452e-ae20-9fde9e1b8c12",
+                        "name": "Day 2, Order 1"
+                    },
+                    "causalType": "Lever",
+                    "position": {
+                        "x": 243.5,
+                        "y": 790.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "409a13e2-d2f5-4833-97ab-8436fbef8758",
+                                "name": "D2O1 Field Selection 1"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#a047ae",
+                                                "end": "#ead4ed"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "f6a1e740-cd83-4941-bf0e-cd51bb097d2e",
+                                "name": "D2O1 Field Selection 2"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#a047ae",
+                                                "end": "#ead4ed"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "f77f594f-e82b-4472-95aa-dfd57b91d636",
+                                "name": "D2O1 Field Selection 3"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#a047ae",
+                                                "end": "#ead4ed"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "528dfb5f-0ec0-435e-9cb0-b04756916283",
+                                "name": "(Info for Day 2, Order 1)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": " ",
+                                    "isInteractive": false
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "5eca7382-643b-4930-8792-25aa2bca265a",
+                        "name": "Day 1, Order 2"
+                    },
+                    "causalType": "Lever",
+                    "position": {
+                        "x": 551.5,
+                        "y": 140.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "81058753-5c19-4278-88b3-eff4d202c80b",
+                                "name": "D1O2 Field Selection 1"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#5c4a73",
+                                                "end": "#c3b7d1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "7a435e55-ebdb-416c-b37f-0004b81b84dc",
+                                "name": "D1O2 Field Selection 2"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#5c4a73",
+                                                "end": "#c3b7d1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "07fdf1f2-8192-4ccb-80a8-1c4894623fee",
+                                "name": "D1O2 Field Selection 3"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        1,
+                                        2,
+                                        3,
+                                        4,
+                                        5,
+                                        6,
+                                        7,
+                                        8,
+                                        "(None)"
+                                    ],
+                                    "selectedValue": "(None)",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": true,
+                                            "dialColorGradient": {
+                                                "start": "#5c4a73",
+                                                "end": "#c3b7d1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "e3ff32e1-cbfd-45c4-b7b2-09b6cf07e0a6",
+                                "name": "(Info for Day 1, Order 2)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": " ",
+                                    "isInteractive": false
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "85102c0a-1c61-47a8-8b72-165df0d658ce",
+                        "name": "Profit"
+                    },
+                    "causalType": "Outcome",
+                    "position": {
+                        "x": 2111.5,
+                        "y": 154.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "f9178bd2-2ca5-484f-b1ad-f1b033904c95",
+                                "name": "Profit"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": " ",
+                                    "isInteractive": false
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "1399d32f-20fa-46b3-912d-3fda5484fd89",
+                                "name": "Cost/Revenue Breakdown"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "C. Swi",
+                                        "C. Sto",
+                                        "C. Wag",
+                                        "Revenue"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 450,
+                                "stepHeight": 20
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "bd3ea38f-220f-47f5-bb08-11ac731543bf",
+                        "name": "Boxes Packed"
+                    },
+                    "causalType": "Intermediate",
+                    "position": {
+                        "x": 1786.5,
+                        "y": 72.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "80e6381e-53fb-455b-909d-83b61e33a61a",
+                                "name": "Packed for Day 1, Order 1"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 10,
+                                    "step": 1,
+                                    "value": 0,
+                                    "isInteractive": false
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": true,
+                                            "gaugeColorGradient": {
+                                                "start": "#788937",
+                                                "end": "#a6fc99"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "ebd26454-c9b4-42f2-8a61-4c9172c0039a",
+                                "name": "Packed for Day 1, Order 2"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 10,
+                                    "step": 1,
+                                    "value": 0,
+                                    "isInteractive": false
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": true,
+                                            "gaugeColorGradient": {
+                                                "start": "#788937",
+                                                "end": "#a6fc99"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "03fabdc4-4df0-4542-a8ae-8f293b5cdff4",
+                                "name": "Packed for Day 2, Order 1"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 10,
+                                    "step": 1,
+                                    "value": 0,
+                                    "isInteractive": false
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": true,
+                                            "gaugeColorGradient": {
+                                                "start": "#788937",
+                                                "end": "#a6fc99"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "e550b053-007d-47de-9cf4-273c8821182c",
+                                "name": "Packed for Day 2, Order 2"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 10,
+                                    "step": 1,
+                                    "value": 0,
+                                    "isInteractive": false
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": true,
+                                            "gaugeColorGradient": {
+                                                "start": "#788937",
+                                                "end": "#a6fc99"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "e76919bc-a0f0-4975-afcb-801b976c306e",
+                        "name": "Field States (1-4)"
+                    },
+                    "causalType": "Intermediate",
+                    "position": {
+                        "x": 858.5,
+                        "y": 21.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "3eb1357a-008e-463b-ac16-526342c6f674",
+                                "name": "Field 1 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "d398c0d9-b822-4892-b839-de997621f2cb",
+                                "name": "Field 2 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "31440d95-7bcf-486e-aa9c-a7996e003fc4",
+                                "name": "Field 3 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "456d4212-5650-4b5e-934a-21433564d598",
+                                "name": "Field 4 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "529153c3-54c7-4cb8-94cb-14bc6c30b64c",
+                        "name": "Field States (5-8)"
+                    },
+                    "causalType": "Intermediate",
+                    "position": {
+                        "x": 1164.5,
+                        "y": 21.75
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "1e37f5ad-8d6c-4bf3-a9d4-9fc0279346ea",
+                                "name": "Field 5 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "571204ae-d4e6-4c52-8182-206dbad2bbfa",
+                                "name": "Field 6 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "8a9fd930-70e0-407b-bf4b-befce591cc95",
+                                "name": "Field 7 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "47278587-a146-4953-9be0-d4eabd2f2bb8",
+                                "name": "Field 8 State"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 800,
+                                "stepHeight": 5
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "98787e20-86f3-415e-bb78-f1093009cea6",
+                        "name": "Day 1, Order 1: Requested Sizes & Boxes"
+                    },
+                    "causalType": "External",
+                    "position": {
+                        "x": 910.5,
+                        "y": 1114.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "28228cb4-f30c-47ef-ac29-da0e2f65479b",
+                                "name": "D1O1 # Boxes Requested"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 20,
+                                    "step": 1,
+                                    "value": 10,
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": false,
+                                            "gaugeColorGradient": {
+                                                "start": "darkgoldenrod",
+                                                "end": "moccasin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "9a6ea6d8-d620-4633-ad64-6b0073ecb55f",
+                                "name": "D1O1 Sizes: S"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "c03bb373-7ac8-4dfc-93f4-fa0f780fb674",
+                                "name": "D1O1 Sizes: M"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "a4ef743e-1631-490b-8efd-994d8b6793a2",
+                                "name": "D1O1 Sizes: L1"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "e3af891a-c3ce-4bfe-b1b3-fabbd89d0a83",
+                                "name": "D1O1 Sizes: L2"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "ed99124d-0c6f-422e-9cf6-601ad9713eef",
+                                "name": "D1O1 Sizes: XL"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "a5f8b630-ef29-4cd8-83de-9d68ae23ef58",
+                                "name": "D1O1 Sizes: G"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "737e0926-751a-4511-987e-ef91a9bcc461",
+                        "name": "Day 2, Order 2: Requested Sizes & Boxes"
+                    },
+                    "causalType": "External",
+                    "position": {
+                        "x": 1852.5,
+                        "y": 1112.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "c749d2b1-eacd-4c66-a36f-0a0790764257",
+                                "name": "D2O2 # Boxes Requested"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 20,
+                                    "step": 1,
+                                    "value": 14,
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": false,
+                                            "gaugeColorGradient": {
+                                                "start": "darkgoldenrod",
+                                                "end": "moccasin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "440aeab8-e4eb-48b2-8987-0da58b41297f",
+                                "name": "D2O2 Sizes: S"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "431f0922-2834-4933-8faa-a6bb8a6961a8",
+                                "name": "D2O2 Sizes: M"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "b68d110e-20d6-45f3-a225-47b71cd1714d",
+                                "name": "D2O2 Sizes: L1"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "4af9ea19-4cbd-4b1a-bbcf-3ed4ee457dec",
+                                "name": "D2O2 Sizes: L2"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "203bfc23-1dde-4a9f-8bc9-c100c0b7b3b6",
+                                "name": "D2O2 Sizes: XL"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "32cd7599-95cf-4e48-ba5a-08da41609537",
+                                "name": "D2O2 Sizes: G"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "df322808-7f5b-4282-826c-6520a22fbed7",
+                        "name": "Day 2, Order 1: Requested Sizes & Boxes"
+                    },
+                    "causalType": "External",
+                    "position": {
+                        "x": 1538.5,
+                        "y": 1115.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "c5c5e7a6-721c-440c-bcab-ffa4020f933a",
+                                "name": "D2O1 # Boxes Requested"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 20,
+                                    "step": 1,
+                                    "value": 6,
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": false,
+                                            "gaugeColorGradient": {
+                                                "start": "darkgoldenrod",
+                                                "end": "moccasin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "fd7f9ad7-3f7f-487f-adef-c18acac2a192",
+                                "name": "D2O1 Sizes: S"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "a6dabaa0-73dc-4b74-8921-0ca123599e4b",
+                                "name": "D2O1 Sizes: M"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "6da70792-a406-4d91-a719-8ebe29561ee7",
+                                "name": "D2O1 Sizes: L1"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "c1ea62df-31fe-43fc-aa8c-1654de6560c1",
+                                "name": "D2O1 Sizes: L2"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "e28d852c-500d-4215-9cf8-083c82d14887",
+                                "name": "D2O1 Sizes: XL"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "52f67042-43ea-464b-8b99-a7ccc39110a6",
+                                "name": "D2O1 Sizes: G"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "30098c22-8203-4b1d-bb31-30a36905dc83",
+                        "name": "Day 1, Order 2: Requested Sizes & Boxes"
+                    },
+                    "causalType": "External",
+                    "position": {
+                        "x": 1225.5,
+                        "y": 1114.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "9cc14bac-dcec-424d-8212-26fbd4627966",
+                                "name": "D1O2 # Boxes Requested"
+                            },
+                            "displayType": "controlRange",
+                            "content": {
+                                "controlParameters": {
+                                    "min": 0,
+                                    "max": 20,
+                                    "step": 1,
+                                    "value": 10,
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isGauge": false,
+                                            "gaugeColorGradient": {
+                                                "start": "darkgoldenrod",
+                                                "end": "moccasin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "f83a26aa-e00f-472c-8c25-2d85d9bc3dcb",
+                                "name": "D1O2 Sizes: S"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "209168ea-9b9c-4535-9813-7912856dd915",
+                                "name": "D1O2 Sizes: M"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "4419314c-3d24-439d-87a9-b1a9c2341ec9",
+                                "name": "D1O2 Sizes: L1"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "e408c9a6-37a2-4602-a038-138d53cd2b3f",
+                                "name": "D1O2 Sizes: L2"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "06098baf-6dc8-478b-9063-9c0c03581a95",
+                                "name": "D1O2 Sizes: XL"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "0b8ec058-acb8-478d-80bd-4da29a0fb068",
+                                "name": "D1O2 Sizes: G"
+                            },
+                            "displayType": "controlBoolean",
+                            "content": {
+                                "controlParameters": {
+                                    "value": false,
+                                    "isInteractive": true
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "69d97997-58d1-42eb-8888-4da7e827334d",
+                        "name": "Storage State"
+                    },
+                    "causalType": "Intermediate",
+                    "position": {
+                        "x": 1475.5,
+                        "y": 23.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "9c855284-820f-49f6-8ad4-6c0c802e80d0",
+                                "name": "Storage after Day 1 Order 1"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 20,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "680476a3-a09e-4ab6-acf5-8756106fd0b9",
+                                "name": "Storage after Day 1 Order 2"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 20,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "26c69bb8-9b54-4984-ba4e-6e33fc92a971",
+                                "name": "Storage after Day 2 Order 1"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 20,
+                                "stepHeight": 5
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "112c31b2-5d41-4d1b-ad2a-d433bad067e4",
+                                "name": "Storage after Day 2 Order 2"
+                            },
+                            "displayType": "stackedBarChart",
+                            "content": {
+                                "data": {
+                                    "xAxisLabels": [
+                                        "S",
+                                        "M",
+                                        "L1",
+                                        "L2",
+                                        "XL",
+                                        "G"
+                                    ],
+                                    "series": [
+                                        {
+                                            "title": "Series 0",
+                                            "values": []
+                                        }
+                                    ]
+                                },
+                                "minY": 0,
+                                "maxY": 20,
+                                "stepHeight": 5
+                            }
+                        }
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "00a513fa-2498-4068-b2ca-c72163bdfc76",
+                        "name": "Decision Configuration"
+                    },
+                    "causalType": "CUSTOM_CONFIG",
+                    "position": {
+                        "x": 417.5,
+                        "y": 2.5
+                    },
+                    "displays": [
+                        {
+                            "meta": {
+                                "uuid": "3296090f-27ad-4aec-8e50-7aa1040bcb44",
+                                "name": "API Key"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": " ",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "d773bf51-e288-48c2-8017-5b20957d9a5b",
+                                "name": "Wages: $/hr"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "2.00",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "7c3233f5-9e8e-4c9a-820c-d8efd467a0c8",
+                                "name": "Time to harvest 1 pound (minutes)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "1",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "56c9084f-c987-4e7e-bc05-7df2199bf960",
+                                "name": "Field Switching: Flat cost ($)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "30",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "09e16ef5-5449-4298-abae-8275829cc622",
+                                "name": "Field Switching: Time to switch (minutes)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "40",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "84a2373b-c21f-435f-8827-d98a1cf4cb98",
+                                "name": "Storage Cost ($/box)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "0.88",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "33871b7f-f8de-4e56-bc46-6a9b6f35389f",
+                                "name": "Revenue ($/box) - Fulfilled orders only"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "15",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "05a6ed20-76ac-415c-a86f-317c1d3a98a9",
+                                "name": "Orders per day (Field switch count resets at the start of each day)"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "2",
+                                    "isInteractive": true
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "b48a746d-3378-4ca1-b121-d361dcd00666",
+                                "name": "Storage Cost Frequency (How often to charge for storage?)"
+                            },
+                            "displayType": "controlSelector",
+                            "content": {
+                                "controlParameters": {
+                                    "options": [
+                                        "Per-order",
+                                        "Per-day"
+                                    ],
+                                    "selectedValue": "Per-day",
+                                    "isInteractive": true
+                                }
+                            },
+                            "addons": {
+                                "ADDON_OpenDIAuthoringTool": {
+                                    "addonMeta": {
+                                        "uuid": "ec427cfd-5f80-4262-afe7-d58e6c4ba566",
+                                        "name": "OpenDI Authoring Tool"
+                                    },
+                                    "owner": {
+                                        "uuid": "f79ae5c2-6ca9-48a2-87fa-4615da6b0f08",
+                                        "name": "Placeholder Owner Info"
+                                    },
+                                    "data": {
+                                        "style": {
+                                            "isDial": false,
+                                            "dialColorGradient": {
+                                                "start": "darkgoldenrod",
+                                                "end": "moccasin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "meta": {
+                                "uuid": "f9c7323f-085b-48d9-9024-163a04ff781f",
+                                "name": "API Note:"
+                            },
+                            "displayType": "controlText",
+                            "content": {
+                                "controlParameters": {
+                                    "value": "API key needed! See model summary.",
+                                    "isInteractive": false
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "dependencies": [
+                {
+                    "meta": {
+                        "uuid": "be854a00-a952-4446-8534-0e1a7e116f43",
+                        "name": "Day 1, Order 1 --> Field States"
+                    },
+                    "source": "7e12015b-2d0f-4bb0-a96d-96fda0f20753",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "1e3e2d6f-0bd7-4c6f-837c-b6b5d535df9d",
+                        "name": "Day 2, Order 1 --> Field States"
+                    },
+                    "source": "0f5e0c26-9c63-452e-ae20-9fde9e1b8c12",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "a453038f-2290-47e7-b192-f784e22c034e",
+                        "name": "Day 2, Order 2 --> Field States"
+                    },
+                    "source": "bddc72ba-fa51-4cb7-89c0-92c57d962ab9",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "79cb5c45-1deb-432c-b0bc-814608d64b83",
+                        "name": "Day 1, Order 2 --> Field States"
+                    },
+                    "source": "5eca7382-643b-4930-8792-25aa2bca265a",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "e11e6cd8-c829-4def-9577-e4a0bd0f0b63",
+                        "name": "Field States --> Boxes Packed"
+                    },
+                    "source": "e76919bc-a0f0-4975-afcb-801b976c306e",
+                    "target": "bd3ea38f-220f-47f5-bb08-11ac731543bf"
+                },
+                {
+                    "meta": {
+                        "uuid": "6ecd9d9d-1542-4ae1-b61a-4cbc6ad0624f",
+                        "name": "Boxes Packed --> Cost/Profit Split"
+                    },
+                    "source": "bd3ea38f-220f-47f5-bb08-11ac731543bf",
+                    "target": "85102c0a-1c61-47a8-8b72-165df0d658ce"
+                },
+                {
+                    "meta": {
+                        "uuid": "4f05efe3-c3f1-4e57-bcb2-e0b6db8e748d",
+                        "name": "Day 1, Order 1 --> New Diagram Element"
+                    },
+                    "source": "7e12015b-2d0f-4bb0-a96d-96fda0f20753",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "f0b09557-8e11-42ff-b638-f3d7b00dd9a6",
+                        "name": "Day 2, Order 1 --> New Diagram Element"
+                    },
+                    "source": "0f5e0c26-9c63-452e-ae20-9fde9e1b8c12",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "db35efed-a4e1-481d-8c73-fbf8b042c3d1",
+                        "name": "Day 1, Order 2 --> New Diagram Element"
+                    },
+                    "source": "5eca7382-643b-4930-8792-25aa2bca265a",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "dfaffdef-450a-421d-8fd9-91c263ee5ad1",
+                        "name": "Day 2, Order 2 --> New Diagram Element"
+                    },
+                    "source": "bddc72ba-fa51-4cb7-89c0-92c57d962ab9",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "7c825e73-821c-47cb-bf7f-4deea9a7bf8d",
+                        "name": "Field States (5-8) --> Boxes Packed"
+                    },
+                    "source": "529153c3-54c7-4cb8-94cb-14bc6c30b64c",
+                    "target": "bd3ea38f-220f-47f5-bb08-11ac731543bf"
+                },
+                {
+                    "meta": {
+                        "uuid": "12ffd79b-48ab-4ae4-ab66-e4327bdb14f0",
+                        "name": "Day 1, Order 1: Requested Sizes --> Field States (1-4)"
+                    },
+                    "source": "98787e20-86f3-415e-bb78-f1093009cea6",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "6ef09169-536a-4949-9681-94bf33122eed",
+                        "name": "Day 1, Order 2: Requested Sizes --> Field States (1-4)"
+                    },
+                    "source": "30098c22-8203-4b1d-bb31-30a36905dc83",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "c91cd729-0798-4647-9c12-4defe49289f6",
+                        "name": "Day 2, Order 1: Requested Sizes --> Field States (1-4)"
+                    },
+                    "source": "df322808-7f5b-4282-826c-6520a22fbed7",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "072e50b3-90a4-477e-bddf-81aba160654d",
+                        "name": "Day 2, Order 2: Requested Sizes --> Field States (1-4)"
+                    },
+                    "source": "737e0926-751a-4511-987e-ef91a9bcc461",
+                    "target": "e76919bc-a0f0-4975-afcb-801b976c306e"
+                },
+                {
+                    "meta": {
+                        "uuid": "cd4f6287-3e6b-4cab-bd92-edf90679a695",
+                        "name": "Day 1, Order 1: Requested Sizes --> Field States (5-8)"
+                    },
+                    "source": "98787e20-86f3-415e-bb78-f1093009cea6",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "8c500e7b-c4a9-40e4-ace6-d8f0b2d64fb2",
+                        "name": "Day 1, Order 2: Requested Sizes --> Field States (5-8)"
+                    },
+                    "source": "30098c22-8203-4b1d-bb31-30a36905dc83",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "21d524e2-0a95-4b66-84c4-2986bc6a4fcd",
+                        "name": "Day 2, Order 1: Requested Sizes --> Field States (5-8)"
+                    },
+                    "source": "df322808-7f5b-4282-826c-6520a22fbed7",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "bb3314c2-5bdf-4905-a7c2-8603beff17c6",
+                        "name": "Day 2, Order 2: Requested Sizes --> Field States (5-8)"
+                    },
+                    "source": "737e0926-751a-4511-987e-ef91a9bcc461",
+                    "target": "529153c3-54c7-4cb8-94cb-14bc6c30b64c"
+                },
+                {
+                    "meta": {
+                        "uuid": "915d310d-9f97-4f3f-bb56-a9d94dda63ee",
+                        "name": "Day 1, Order 1 --> Storage State"
+                    },
+                    "source": "7e12015b-2d0f-4bb0-a96d-96fda0f20753",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "0a36f657-62e7-4418-9dd3-c8424e9d7be1",
+                        "name": "Day 1, Order 2 --> Storage State"
+                    },
+                    "source": "5eca7382-643b-4930-8792-25aa2bca265a",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "df210026-fc99-4b5c-9418-1cb5245b2266",
+                        "name": "Day 2, Order 1 --> Storage State"
+                    },
+                    "source": "0f5e0c26-9c63-452e-ae20-9fde9e1b8c12",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "36162571-795c-4ef9-8cdf-3b84c329ece1",
+                        "name": "Day 2, Order 2 --> Storage State"
+                    },
+                    "source": "bddc72ba-fa51-4cb7-89c0-92c57d962ab9",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "c74e17b6-bf86-4ea8-94d7-d71a4b50674f",
+                        "name": "Day 1, Order 1: Requested Sizes & Boxes --> Storage State"
+                    },
+                    "source": "98787e20-86f3-415e-bb78-f1093009cea6",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "366d8d4f-f7ec-44a3-9ac2-763a12becd0b",
+                        "name": "Day 1, Order 2: Requested Sizes & Boxes --> Storage State"
+                    },
+                    "source": "30098c22-8203-4b1d-bb31-30a36905dc83",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "92775c1b-f129-4919-87f3-c5298b0f0e17",
+                        "name": "Day 2, Order 1: Requested Sizes & Boxes --> Storage State"
+                    },
+                    "source": "df322808-7f5b-4282-826c-6520a22fbed7",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                },
+                {
+                    "meta": {
+                        "uuid": "bb49a175-1def-4f5e-8ed8-cb3ad90ed6bd",
+                        "name": "Day 2, Order 2: Requested Sizes & Boxes --> Storage State"
+                    },
+                    "source": "737e0926-751a-4511-987e-ef91a9bcc461",
+                    "target": "69d97997-58d1-42eb-8888-4da7e827334d"
+                }
+            ]
+        }
+    ],
+    "runnableModels": [
+        {
+            "meta": {
+                "uuid": "47709d20-018d-49e4-8fb8-88e3973647c3",
+                "name": "Packing Simulation",
+                "createdDate": "2025-07-25T18:37:53-04:00"
+            },
+            "elements": [
+                {
+                    "meta": {
+                        "uuid": "ece9e7f5-98a7-474d-85b0-c329937a0905",
+                        "name": "Retrieve Field Data: Create URI Endpoint"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "createAPIEndpointExtension",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "d2615f0e-df57-478f-909d-5f2b71ff9621"
+                    ],
+                    "outputs": [
+                        "9ab4c1a7-8ac2-480e-8822-b99e4c7d8150"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "47720467-8567-415e-88c2-9c3bee43ab76",
+                        "name": "Retrieve Field Data: API Call"
+                    },
+                    "evaluatableAsset": "80fe081f-aa1b-4cc1-b954-5f4004dc6a32",
+                    "functionName": "",
+                    "apiCacheSize": 1,
+                    "inputs": [
+                        "b8996b53-42d9-48f8-8366-1ee733e2cc10",
+                        "9ab4c1a7-8ac2-480e-8822-b99e4c7d8150"
+                    ],
+                    "outputs": [
+                        "7ed86747-394c-4360-88c3-b15dbfbccf73"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "4b503401-3c95-426b-bba1-c765446a1442",
+                        "name": "Retrieve Field Data: Process API Results"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "processFieldJSON",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "7ed86747-394c-4360-88c3-b15dbfbccf73"
+                    ],
+                    "outputs": [
+                        "b56ee97b-008a-4daf-8eca-97936d1149d1"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "5f16949d-5904-4dd1-a8c9-1945bd994881",
+                        "name": "Simulate Packing"
+                    },
+                    "evaluatableAsset": "e2b824b6-fb6c-4e52-aa94-17bd780a75ed",
+                    "functionName": "simulatePacking",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "b56ee97b-008a-4daf-8eca-97936d1149d1",
+                        "53aca32e-6793-46f7-901f-679131dc201d",
+                        "d9ec0a99-fc22-4bd6-b0ae-ca1f20d62666",
+                        "2c6f5d80-f618-4099-8b7d-ceeeeac955e6",
+                        "b56b1a3c-82a3-4312-9c74-ed1e95bee5fd"
+                    ],
+                    "outputs": [
+                        "42f7bf91-3452-40b9-a1df-351c4a7c61df",
+                        "bcff236f-b29a-4214-80e9-b501423ab654",
+                        "9d13ee13-1ca0-4333-aa91-84cbbfa6b389",
+                        "813d2baf-923c-497c-9511-fae72e8b6085",
+                        "63262663-fd67-4e61-a4e3-23d69606324a",
+                        "007b5928-6913-4337-9142-b8d72b7c746c",
+                        "99808134-6298-4b6f-af10-dc052f9c0038",
+                        "9949e3f9-0b8e-41d3-b627-40d856f7112d",
+                        "438d09fe-2d3d-4ad6-9444-ff9c6a8c14e7",
+                        "12b045f7-a0a4-48e3-ab5d-97a50b8831a7",
+                        "3a9d5227-2e8c-4a75-af5d-6f0d54111251",
+                        "bbaac339-a870-4ac5-9f35-36da8fe9e864",
+                        "b8787e50-1e79-494a-9475-eb1f25c7c70b",
+                        "cf48172b-a508-42c0-a99b-3fe11b8c0be8",
+                        "0061b32f-309c-4069-b2cb-cd4aaf76b59f",
+                        "00277ca1-a9ea-474f-9f22-4bac0829cb25",
+                        "760d9ec4-ba18-41b6-867c-cc89d9d6afe3",
+                        "131747d0-00a3-474e-ad2d-10016a9f9be3"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "d12277ed-adcd-43e6-b287-4ed688378c62",
+                        "name": "Combine all requested order sizes"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "getRequestedOrderSizes",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "f540798b-6ffc-4a10-95f4-d07bcc3eb1aa",
+                        "852e9d7a-3dbd-43e2-9f32-bbe27ca9379d",
+                        "99076810-7e7c-4e7e-b231-e2ece8fb78c4",
+                        "4e5fae8a-7ce6-4427-bff9-863186dd457e",
+                        "74b14458-534c-41a8-a493-7fb342f3760d",
+                        "dc7dca81-7543-4ca2-b2a1-44a108d385a7",
+                        "64325833-330a-4e60-a6e2-731982997d04",
+                        "122419a0-3eab-400a-bffe-7d0821d850ae",
+                        "2d11e584-b09c-48b8-b60c-ea328596a7d8",
+                        "b7d38390-eb3b-4777-9446-5a71fbaf3f6c",
+                        "4e9b7846-5649-43e2-a24b-e6acc7a14041",
+                        "588ff155-0886-4267-891c-331f8dd597a1",
+                        "4fcb6038-2c20-4c5f-bbd9-2a8746caee5b",
+                        "38486fde-872e-4f3f-b7e7-c48c4494e7c9",
+                        "3009a4c2-a396-4935-9e41-916daeff3a4f",
+                        "42eec37f-6f05-4cdc-bfb9-8d7b9c363348",
+                        "3f9d5d2f-2f7f-4f34-8c4f-aa45b01ac522",
+                        "29e400b0-50e1-4aa4-9477-62a48cf4868b",
+                        "43da83a1-4197-4c38-a29f-54ea3a881bbb",
+                        "63b16da1-ca85-4332-9b72-02c77b82be71",
+                        "ec309d92-7210-4b18-ae92-d8c8710864bb",
+                        "46512069-cf25-4a54-969e-8cc58b6d0d64",
+                        "b48fbe16-82f3-4816-ace6-226f6c4abb19",
+                        "572d663e-ce15-482b-b2cd-7fdafc3849da"
+                    ],
+                    "outputs": [
+                        "d9ec0a99-fc22-4bd6-b0ae-ca1f20d62666"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "3b5ca223-ddc8-428d-8187-fcc051cf762f",
+                        "name": "Combine all requested boxes per order"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "getRequestedBoxesPerOder",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "5bbae604-6eec-4b3e-8a0a-322e9a3ebfb9",
+                        "713df129-6ebb-4469-b620-62f1d0b51899",
+                        "ed143517-e7a2-4852-88ad-be5bab8e393a",
+                        "02cbc8d6-3079-42de-8f69-30f3a33f6da0"
+                    ],
+                    "outputs": [
+                        "2c6f5d80-f618-4099-8b7d-ceeeeac955e6"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "206fdc68-694f-42db-94af-10c4a8b8c26b",
+                        "name": "Populate order info strings"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "populateOrderInfoStrings",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "d9ec0a99-fc22-4bd6-b0ae-ca1f20d62666",
+                        "2c6f5d80-f618-4099-8b7d-ceeeeac955e6"
+                    ],
+                    "outputs": [
+                        "fda8ca0f-7948-4194-bf73-c6dcf968209c",
+                        "970876ef-74ff-428a-a993-63d331f32ef4",
+                        "6cc8178d-2ce1-4357-8894-640264c23a13",
+                        "62755287-41a9-4b84-8dc5-cf4e5136a653"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "7b7d1c3f-974e-4d0f-ae96-e5a172fda7c5",
+                        "name": "Combine all order field selections"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "getFieldSelectionsForAllOrders",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "c3210bb6-a1aa-443c-ae66-4904b3dcc57d",
+                        "aab47c8d-edee-43ef-ae29-893e9ba3cac9",
+                        "ace9103e-b6ad-42cd-87c4-7c8dbc3073af",
+                        "39f6742e-3f6c-436c-a009-41069451ff68",
+                        "c2abcd03-00d3-4247-acaf-7adbdf60a9c8",
+                        "54c2667d-1b16-44a2-9c30-dbcce982e3c0",
+                        "bca66c5b-915b-4732-8d66-3c650a251398",
+                        "0a1527ea-bce6-4571-9f00-b5db62611532",
+                        "23b0018e-4d99-4ecb-88f4-3e382bd846a2",
+                        "973752e2-ec80-4d1e-a1eb-640a67c0eddc",
+                        "70e2d74f-34a5-46c5-bb6c-6d15cb8b37f8",
+                        "3935c9a1-4e1d-4c27-ad47-7d5b42225bcf"
+                    ],
+                    "outputs": [
+                        "53aca32e-6793-46f7-901f-679131dc201d"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "8c36318a-3fa2-45dd-944a-c3878fe9ca3f",
+                        "name": "Decision Configuration"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "getDecisionConfig",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "41791496-99c2-4090-9461-94043255ba3b",
+                        "988b4330-3650-4fd9-9f07-9b7dbf505507",
+                        "f2a0301d-667d-4104-acd2-7f937447a18e",
+                        "75fab4bd-8594-4b3f-8cfb-8f9cdfec1c3d",
+                        "f8429046-8bbc-4df8-a06f-11e5685a6982",
+                        "75d48c06-4c46-4d08-972d-e3dd35ed1e15",
+                        "d52d11c9-6ffe-4201-8d83-0e8603fefa1f",
+                        "55678c78-4b7a-413e-be6f-972baae59ad7"
+                    ],
+                    "outputs": [
+                        "b56b1a3c-82a3-4312-9c74-ed1e95bee5fd"
+                    ]
+                },
+                {
+                    "meta": {
+                        "uuid": "9cf6e449-57ba-4b02-8d74-3ebcd29d613c",
+                        "name": "Check for API key"
+                    },
+                    "evaluatableAsset": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                    "functionName": "checkAPIKeyFound",
+                    "apiCacheSize": 2,
+                    "inputs": [
+                        "d2615f0e-df57-478f-909d-5f2b71ff9621"
+                    ],
+                    "outputs": [
+                        "27aed0e0-84c8-4db9-a369-b3c809c09046"
+                    ]
+                }
+            ]
+        }
+    ],
+    "inputOutputValues": [
+        {
+            "meta": {
+                "uuid": "7ed86747-394c-4360-88c3-b15dbfbccf73",
+                "name": "Google Sheets API Data"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "b56ee97b-008a-4daf-8eca-97936d1149d1",
+                "name": "Initial Field Contents"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "42f7bf91-3452-40b9-a1df-351c4a7c61df",
+                "name": "Field 1 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "bcff236f-b29a-4214-80e9-b501423ab654",
+                "name": "Field 2 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "9d13ee13-1ca0-4333-aa91-84cbbfa6b389",
+                "name": "Field 3 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "813d2baf-923c-497c-9511-fae72e8b6085",
+                "name": "Field 4 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "63262663-fd67-4e61-a4e3-23d69606324a",
+                "name": "Field 5 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "007b5928-6913-4337-9142-b8d72b7c746c",
+                "name": "Field 6 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "99808134-6298-4b6f-af10-dc052f9c0038",
+                "name": "Field 7 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "9949e3f9-0b8e-41d3-b627-40d856f7112d",
+                "name": "Field 8 State"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "f540798b-6ffc-4a10-95f4-d07bcc3eb1aa",
+                "name": "Requested Sizes: Day 1 Order 1 \"S\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "852e9d7a-3dbd-43e2-9f32-bbe27ca9379d",
+                "name": "Requested Sizes: Day 1 Order 1 \"M\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "99076810-7e7c-4e7e-b231-e2ece8fb78c4",
+                "name": "Requested Sizes: Day 1 Order 1 \"L1\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "4e5fae8a-7ce6-4427-bff9-863186dd457e",
+                "name": "Requested Sizes: Day 1 Order 1 \"L2\""
+            },
+            "data": true
+        },
+        {
+            "meta": {
+                "uuid": "74b14458-534c-41a8-a493-7fb342f3760d",
+                "name": "Requested Sizes: Day 1 Order 1 \"XL\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "dc7dca81-7543-4ca2-b2a1-44a108d385a7",
+                "name": "Requested Sizes: Day 1 Order 1 \"G\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "64325833-330a-4e60-a6e2-731982997d04",
+                "name": "Requested Sizes: -Day 1 Order 2 \"S\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "122419a0-3eab-400a-bffe-7d0821d850ae",
+                "name": "Requested Sizes: -Day 1 Order 2 \"M\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "2d11e584-b09c-48b8-b60c-ea328596a7d8",
+                "name": "Requested Sizes: -Day 1 Order 2 \"L1\""
+            },
+            "data": true
+        },
+        {
+            "meta": {
+                "uuid": "b7d38390-eb3b-4777-9446-5a71fbaf3f6c",
+                "name": "Requested Sizes: -Day 1 Order 2 \"L2\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "4e9b7846-5649-43e2-a24b-e6acc7a14041",
+                "name": "Requested Sizes: -Day 1 Order 2 \"XL\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "588ff155-0886-4267-891c-331f8dd597a1",
+                "name": "Requested Sizes: -Day 1 Order 2 \"G\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "4fcb6038-2c20-4c5f-bbd9-2a8746caee5b",
+                "name": "Requested Sizes: Day 2 Order 1 \"S\""
+            },
+            "data": true
+        },
+        {
+            "meta": {
+                "uuid": "38486fde-872e-4f3f-b7e7-c48c4494e7c9",
+                "name": "Requested Sizes: Day 2 Order 1 \"M\""
+            },
+            "data": true
+        },
+        {
+            "meta": {
+                "uuid": "3009a4c2-a396-4935-9e41-916daeff3a4f",
+                "name": "Requested Sizes: Day 2 Order 1 \"L1\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "42eec37f-6f05-4cdc-bfb9-8d7b9c363348",
+                "name": "Requested Sizes: Day 2 Order 1 \"L2\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "3f9d5d2f-2f7f-4f34-8c4f-aa45b01ac522",
+                "name": "Requested Sizes: Day 2 Order 1 \"XL\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "29e400b0-50e1-4aa4-9477-62a48cf4868b",
+                "name": "Requested Sizes: Day 2 Order 1 \"G\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "43da83a1-4197-4c38-a29f-54ea3a881bbb",
+                "name": "Requested Sizes: -Day 2 Order 2 \"S\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "63b16da1-ca85-4332-9b72-02c77b82be71",
+                "name": "Requested Sizes: -Day 2 Order 2 \"M\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "ec309d92-7210-4b18-ae92-d8c8710864bb",
+                "name": "Requested Sizes: -Day 2 Order 2 \"L1\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "46512069-cf25-4a54-969e-8cc58b6d0d64",
+                "name": "Requested Sizes: -Day 2 Order 2 \"L2\""
+            },
+            "data": true
+        },
+        {
+            "meta": {
+                "uuid": "b48fbe16-82f3-4816-ace6-226f6c4abb19",
+                "name": "Requested Sizes: -Day 2 Order 2 \"XL\""
+            },
+            "data": true
+        },
+        {
+            "meta": {
+                "uuid": "572d663e-ce15-482b-b2cd-7fdafc3849da",
+                "name": "Requested Sizes: -Day 2 Order 2 \"G\""
+            },
+            "data": false
+        },
+        {
+            "meta": {
+                "uuid": "5bbae604-6eec-4b3e-8a0a-322e9a3ebfb9",
+                "name": "Requested Boxes: Day 1 Order 1"
+            },
+            "data": 10
+        },
+        {
+            "meta": {
+                "uuid": "713df129-6ebb-4469-b620-62f1d0b51899",
+                "name": "Requested Boxes: -Day 1 Order 2"
+            },
+            "data": 10
+        },
+        {
+            "meta": {
+                "uuid": "ed143517-e7a2-4852-88ad-be5bab8e393a",
+                "name": "Requested Boxes: Day 2 Order 1"
+            },
+            "data": 6
+        },
+        {
+            "meta": {
+                "uuid": "02cbc8d6-3079-42de-8f69-30f3a33f6da0",
+                "name": "Requested Boxes: -Day 2 Order 2"
+            },
+            "data": 14
+        },
+        {
+            "meta": {
+                "uuid": "fda8ca0f-7948-4194-bf73-c6dcf968209c",
+                "name": "Day 1 Order 1 Info String"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "970876ef-74ff-428a-a993-63d331f32ef4",
+                "name": "Day 1 Order 2 Info String"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "6cc8178d-2ce1-4357-8894-640264c23a13",
+                "name": "Day 2 Order 1 Info String"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "62755287-41a9-4b84-8dc5-cf4e5136a653",
+                "name": "Day 2 Order 2 Info String"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "d9ec0a99-fc22-4bd6-b0ae-ca1f20d62666",
+                "name": "COMBINED Requested Order Sizes"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "2c6f5d80-f618-4099-8b7d-ceeeeac955e6",
+                "name": "COMBINED Requested Order Box Amounts"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "267e8d98-6c18-4111-b12b-57e926ba87a1",
+                "name": "Global \"Boxes Packed\" Minimum"
+            },
+            "data": 0
+        },
+        {
+            "meta": {
+                "uuid": "438d09fe-2d3d-4ad6-9444-ff9c6a8c14e7",
+                "name": "Boxes Packed For Day 1, Order 1"
+            },
+            "data": 0
+        },
+        {
+            "meta": {
+                "uuid": "12b045f7-a0a4-48e3-ab5d-97a50b8831a7",
+                "name": "Boxes Packed For Day 1, Order 2"
+            },
+            "data": 0
+        },
+        {
+            "meta": {
+                "uuid": "3a9d5227-2e8c-4a75-af5d-6f0d54111251",
+                "name": "Boxes Packed For Day 2, Order 1"
+            },
+            "data": 0
+        },
+        {
+            "meta": {
+                "uuid": "bbaac339-a870-4ac5-9f35-36da8fe9e864",
+                "name": "Boxes Packed For Day 2, Order 2"
+            },
+            "data": 0
+        },
+        {
+            "meta": {
+                "uuid": "c3210bb6-a1aa-443c-ae66-4904b3dcc57d",
+                "name": "Field Selection: D1O1 Sel 1"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "aab47c8d-edee-43ef-ae29-893e9ba3cac9",
+                "name": "Field Selection: D1O1 Sel 2"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "ace9103e-b6ad-42cd-87c4-7c8dbc3073af",
+                "name": "Field Selection: D1O1 Sel 3"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "39f6742e-3f6c-436c-a009-41069451ff68",
+                "name": "Field Selection: -D1O2 Sel 1"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "c2abcd03-00d3-4247-acaf-7adbdf60a9c8",
+                "name": "Field Selection: -D1O2 Sel 2"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "54c2667d-1b16-44a2-9c30-dbcce982e3c0",
+                "name": "Field Selection: -D1O2 Sel 3"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "bca66c5b-915b-4732-8d66-3c650a251398",
+                "name": "Field Selection: D2O1 Sel 1"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "0a1527ea-bce6-4571-9f00-b5db62611532",
+                "name": "Field Selection: D2O1 Sel 2"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "23b0018e-4d99-4ecb-88f4-3e382bd846a2",
+                "name": "Field Selection: D2O1 Sel 3"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "973752e2-ec80-4d1e-a1eb-640a67c0eddc",
+                "name": "Field Selection: -D2O2 Sel 1"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "70e2d74f-34a5-46c5-bb6c-6d15cb8b37f8",
+                "name": "Field Selection: -D2O2 Sel 2"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "3935c9a1-4e1d-4c27-ad47-7d5b42225bcf",
+                "name": "Field Selection: -D2O2 Sel 3"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "53aca32e-6793-46f7-901f-679131dc201d",
+                "name": "COMBINED field selections"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "b8787e50-1e79-494a-9475-eb1f25c7c70b",
+                "name": "Storage after D1O1"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "cf48172b-a508-42c0-a99b-3fe11b8c0be8",
+                "name": "Storage after D1O2"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "0061b32f-309c-4069-b2cb-cd4aaf76b59f",
+                "name": "Storage after D2O1"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "00277ca1-a9ea-474f-9f22-4bac0829cb25",
+                "name": "Storage after D2O2"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "760d9ec4-ba18-41b6-867c-cc89d9d6afe3",
+                "name": "Cost/Revenue Split Report"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "131747d0-00a3-474e-ad2d-10016a9f9be3",
+                "name": "Total Profit"
+            },
+            "data": "$0.00"
+        },
+        {
+            "meta": {
+                "uuid": "d2615f0e-df57-478f-909d-5f2b71ff9621",
+                "name": "API Key"
+            },
+            "data": ""
+        },
+        {
+            "meta": {
+                "uuid": "988b4330-3650-4fd9-9f07-9b7dbf505507",
+                "name": "Config: Wages"
+            },
+            "data": "2.00"
+        },
+        {
+            "meta": {
+                "uuid": "41791496-99c2-4090-9461-94043255ba3b",
+                "name": "Config: Time to harvest 1 pound"
+            },
+            "data": "1"
+        },
+        {
+            "meta": {
+                "uuid": "f2a0301d-667d-4104-acd2-7f937447a18e",
+                "name": "Config: Field Switching Flat Cost"
+            },
+            "data": "30.00"
+        },
+        {
+            "meta": {
+                "uuid": "75fab4bd-8594-4b3f-8cfb-8f9cdfec1c3d",
+                "name": "Config: Field Switching Time"
+            },
+            "data": "40"
+        },
+        {
+            "meta": {
+                "uuid": "f8429046-8bbc-4df8-a06f-11e5685a6982",
+                "name": "Config: Storage Cost"
+            },
+            "data": "0.88"
+        },
+        {
+            "meta": {
+                "uuid": "75d48c06-4c46-4d08-972d-e3dd35ed1e15",
+                "name": "Config: Revenue Per Box"
+            },
+            "data": "15.00"
+        },
+        {
+            "meta": {
+                "uuid": "d52d11c9-6ffe-4201-8d83-0e8603fefa1f",
+                "name": "Config: Orders Per Day"
+            },
+            "data": "2"
+        },
+        {
+            "meta": {
+                "uuid": "b56b1a3c-82a3-4312-9c74-ed1e95bee5fd",
+                "name": "COMBINED Config object"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "b8996b53-42d9-48f8-8366-1ee733e2cc10",
+                "name": "Retrieve Field Data: Request body"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "9ab4c1a7-8ac2-480e-8822-b99e4c7d8150",
+                "name": "Retrieve Field Data: URI Extension"
+            },
+            "data": null
+        },
+        {
+            "meta": {
+                "uuid": "27aed0e0-84c8-4db9-a369-b3c809c09046",
+                "name": "API Key Note"
+            },
+            "data": "API KEY NEEDED! See model summary."
+        },
+        {
+            "meta": {
+                "uuid": "55678c78-4b7a-413e-be6f-972baae59ad7",
+                "name": "Config: Storage Cost Frequency"
+            },
+            "data": "Per-day"
+        }
+    ],
+    "evaluatableAssets": [
+        {
+            "meta": {
+                "uuid": "80fe081f-aa1b-4cc1-b954-5f4004dc6a32",
+                "name": "Retrieve Field Info from Google Sheets",
+                "summary": "This requires an API key. Check model summary for details."
+            },
+            "evalType": "APICall",
+            "content": {
+                "endpointURI": "https://sheets.googleapis.com/v4/spreadsheets/1tG8a55vwriYvKbSx23KOjBLhMS-OX0oFaKzSMl9fvYI",
+                "restMethod": "GET",
+                "defaultPayload": {},
+                "defaultURIExtension": ""
+            }
+        },
+        {
+            "meta": {
+                "uuid": "e2b824b6-fb6c-4e52-aa94-17bd780a75ed",
+                "name": "Simulate Packing",
+                "summary": "The primary packing simulation function. All packing sim logic is in here!"
+            },
+            "evalType": "Script",
+            "content": {
+                "language": "javascript",
+                "script": "KGZ1bmN0aW9uICgpIHsKICAgIGNvbnN0IHNpbXVsYXRlUGFja2luZyA9IGZ1bmN0aW9uKGlucHV0cykKICAgIHsKICAgICAgICBjb25zdCByYXdGaWVsZFBvdGF0b0RhdGEgPSBpbnB1dHNbMF07IC8vQSAyRCBhcnJheS4gRWFjaCBpbm5lciBhcnJheSBpcyBhIGxpc3Qgb2YgcG90YXRvZXMgaW4gdGhhdCBmaWVsZC4KICAgICAgICBjb25zdCBvcmRlckZpZWxkU2VsZWN0aW9ucyA9IGlucHV0c1sxXTsKICAgICAgICBjb25zdCByZXF1ZXN0ZWRPcmRlclNpemVzID0gaW5wdXRzWzJdOwogICAgICAgIGNvbnN0IHJlcXVlc3RlZE9yZGVyQm94ZXMgPSBpbnB1dHNbM107CiAgICAgICAgY29uc3QgZGVjaXNpb25Db25maWcgPSBpbnB1dHNbNF07CiAgICAgICAgY29uc3QgYm94T3VuY2VzID0gNjQwOyAvLzQwbGJzCiAgICAgICAgY29uc3Qgb3JkZXJzUGVyRGF5ID0gZGVjaXNpb25Db25maWcub3JkZXJzUGVyRGF5OwogICAgICAgIGNvbnN0IHN0b3JhZ2VDb3N0SXNQZXJEYXkgPSBkZWNpc2lvbkNvbmZpZy5zdG9yYWdlQ29zdElzUGVyRGF5OwoKICAgICAgICAvLyBjb25zb2xlLmxvZygiU1RBUlQgUEFDS0lORyBTSU0iKTsKICAgICAgICAKICAgICAgICAvL0ZvciBjYXRlZ29yaXppbmcgYnkgc2l6ZTogUywgTSwgTDEsIEwyLCBYTCwgRwogICAgICAgIC8vIEZvciBTIHBvdGF0b2VzLCAwIDwgd2VpZ2h0IDwgNS4zCiAgICAgICAgLy8gRm9yIE0gcG90YXRvZXMsIDUuMyA8PSB3ZWlnaHQgPCAxMC42CiAgICAgICAgLy8gZXRjLgogICAgICAgIGNvbnN0IHNpemVCb3VuZHMgPSBbNS4zLCAxMC42LCAxNS45LCAyMS4yLCAyOC4yLCA0MF07CiAgICAgICAgY29uc3Qgc2l6ZUxhYmVscyA9IFsiUyIsICJNIiwgIkwxIiwgIkwyIiwgIlhMIiwgIkciXTsKCiAgICAgICAgLy9HaXZlbiBhIHBvdGF0byB3ZWlnaHQsIGNhdGVnb3JpemUgaXQgYnkgc2l6ZQogICAgICAgIC8vUmV0dXJucyBhbiBpbmRleCBjb3JyZXNwb25kaW5nIHRvIG9uZSBvZiB0aGUgc2l6ZSBsYWJlbHMgaW4gc2l6ZUxhYmVscwogICAgICAgIGNvbnN0IGdldFNpemVJZHhGb3JQb3RhdG8gPSAocG90YXRvV2VpZ2h0KSA9PiB7CiAgICAgICAgICAgIGZvcihsZXQgc2l6ZUlkeCA9IDA7IHNpemVJZHggPCBzaXplQm91bmRzLmxlbmd0aDsgc2l6ZUlkeCsrKQogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICBpZihwb3RhdG9XZWlnaHQgPCBzaXplQm91bmRzW3NpemVJZHhdKQogICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgIHJldHVybiBzaXplSWR4OwogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgICAgIHJldHVybiBzaXplQm91bmRzLmxlbmd0aCAtIDE7CiAgICAgICAgfQoKICAgICAgICAvL0dlbmVyYXRlIGEgZGF0YSBzZXJpZXMgb2YgcG90YXRvIGNvdW50cyBmcm9tIGEgbGlzdCBvZiBwb3RhdG8gd2VpZ2h0cy4KICAgICAgICAvL1RoaXMgZnVuY3Rpb24gd2lsbCBjYXRlZ29yaXplIGVhY2ggcG90YXRvIGluIHRoZSBwcm92aWRlZCBsaXN0IGJ5IHNpemUsCiAgICAgICAgLy90aGVuIHJldHVybiBhIGxpc3Qgd2l0aCB0aGUgdG90YWwgY291bnQgb2YgcG90YXRvZXMgaW4gZWFjaCBzaXplCiAgICAgICAgLy9jYXRlZ29yeQogICAgICAgIGNvbnN0IG1ha2VGaWVsZFNlcmllc0Zyb21Qb3RhdG9MaXN0ID0gKHBvdGF0b1dlaWdodExpc3QpID0+IHsKCiAgICAgICAgICAgIC8vVG90YWwgY291bnQgb2YgcG90YXRvZXMgaW4gdGhlIGdpdmVuIGxpc3QsIGNhdGVnb3JpemVkIGJ5IHNpemUKICAgICAgICAgICAgY29uc3QgZmllbGRTZXJpZXMgPSBzaXplTGFiZWxzLm1hcCgoKSA9PiAwKTsKCiAgICAgICAgICAgIHBvdGF0b1dlaWdodExpc3QuZm9yRWFjaCgocG90YXRvV2VpZ2h0KSA9PiB7CiAgICAgICAgICAgICAgICBjb25zdCBzaXplSWR4ID0gZ2V0U2l6ZUlkeEZvclBvdGF0byhwb3RhdG9XZWlnaHQpOwogICAgICAgICAgICAgICAgZmllbGRTZXJpZXNbc2l6ZUlkeF0gKz0gMTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICAvL1RvdGFsIHdlaWdodHMgb2YgYWxsIHBvdGF0b2VzIGluIGVhY2ggc2l6ZSBjYXRlZ29yeQogICAgICAgICAgICByZXR1cm4gZmllbGRTZXJpZXM7CiAgICAgICAgfQoKICAgICAgICAvL0luaXRpYWxpemUgYSBidW5jaCBvZiBwYWNraW5nIHN0YXRlCiAgICAgICAgY29uc3QgbnVtT3JkZXJzID0gcmVxdWVzdGVkT3JkZXJCb3hlcy5sZW5ndGg7CiAgICAgICAgbGV0IHBvdGF0b2VzVGFrZW5Gcm9tRWFjaEZpZWxkUGVyT3JkZXIgPSBbXTsgICAgLy8iTnVtYmVyIG9mIHBvdGF0b2VzIGhhcnZlc3RlZCBmcm9tIGZpZWxkIFtmXSBieSBvcmRlciBbb10iID09IHBvdGF0b2VzVGFrZW5Gcm9tRWFjaEZpZWxkUGVyT3JkZXJbb11bZl0KICAgICAgICBsZXQgb3pQYWNrZWRQZXJPcmRlciA9IFtdOyAgICAgICAgICAgICAgICAgICAgICAvL0ZvciBjYWxjdWxhdGluZyBwcm9ncmVzcyB0b3dhcmQgcGFja2luZyBlYWNoIG9yZGVyCiAgICAgICAgbGV0IG96SGFydmVzdGVkUGVyT3JkZXIgPSBbXTsgICAgICAgICAgICAgICAgICAgLy9Gb3IgY2FsY3VsYXRpbmcgd2FnZXMuIEluY2x1ZGVzIGFsbCBwb3RhdG9lcyBoYXJ2ZXN0ZWQgZnJvbSBmaWVsZHMsIHdoZXRoZXIgdGhleSBnbyB0byBzdG9yYWdlIG9yIHRvIGFuIG9yZGVyCiAgICAgICAgbGV0IHN0b3JhZ2VTdGF0ZVBlck9yZGVyID0gW107ICAgICAgICAgICAgICAgICAgLy9MaXN0IG9mIG51bWJlciBvZiBiaW5zIHN0b3JlZCBpbiBlYWNoIHNpemUgY2F0ZWdvcnkgYWZ0ZXIgZWFjaCBvcmRlcgogICAgICAgIGxldCBmaWVsZFN3aXRjaENvdW50UGVyT3JkZXIgPSBbXTsgICAgICAgICAgICAgIC8vTnVtYmVyIG9mIHRpbWVzIHdlIHN3aXRjaGVkIGZpZWxkcywgZm9yIGZpZWxkLXN3aXRjaGluZyBjb3N0CiAgICAgICAgbGV0IG9yZGVyQ29sb3JzID0gWwogICAgICAgICAgICAiIzgxYTVjMyIsICIjOGY3OWFhIiwKICAgICAgICAgICAgIiNjNzhkZDAiLCAiI2E2Njg4MiIsCiAgICAgICAgICAgICIjOGE3NDVmIiwgIiM2NTcwMzkiICAgICAgICAgICAgICAgICAgICAgICAgLy9BIGZldyBtb3JlIGNvbG9ycyB0aGFuIHdlIGN1cnJlbnRseSBuZWVkLCBpbiBjYXNlIHdlIGFkZCBtb3JlIG9yZGVycwogICAgICAgIF07CiAgICAgICAgLy9GaWxsIHplcm9lcyBpbnRvIHRoZSBhYm92ZSBsaXN0cwogICAgICAgIGZvcihsZXQgaSA9IDA7IGkgPCBudW1PcmRlcnM7IGkrKykKICAgICAgICB7CiAgICAgICAgICAgIHBvdGF0b2VzVGFrZW5Gcm9tRWFjaEZpZWxkUGVyT3JkZXIucHVzaChyYXdGaWVsZFBvdGF0b0RhdGEubWFwKCgpID0+IDApKTsgLy8wIHRha2VuIGZyb20gZWFjaCBmaWVsZCBkdXJpbmcgZWFjaCBvcmRlciAoc28gZmFyKQogICAgICAgICAgICBvelBhY2tlZFBlck9yZGVyLnB1c2goMCk7CiAgICAgICAgICAgIG96SGFydmVzdGVkUGVyT3JkZXIucHVzaCgwKTsKICAgICAgICAgICAgZmllbGRTd2l0Y2hDb3VudFBlck9yZGVyLnB1c2goMCk7CiAgICAgICAgICAgIC8vU3RvcmFnZSBiaW5zIGFyZSBzaXplLXNvcnRlZCBzbyB3ZSBoYXZlIHN0b3JhZ2Ugc3RhdHMgcGVyIHNpemUgbGFiZWwKICAgICAgICAgICAgc3RvcmFnZVN0YXRlUGVyT3JkZXIucHVzaChzaXplTGFiZWxzLm1hcCgoKSA9PiAwKSk7CiAgICAgICAgfQoKICAgICAgICAvL1Byb2Nlc3MgZWFjaCBvcmRlcgogICAgICAgIGxldCBwcmV2U2VsZWN0ZWRGaWVsZCA9IC0xOwogICAgICAgIGZvcihsZXQgb3JkZXJJZHggPSAwOyBvcmRlcklkeCA8IG51bU9yZGVyczsgb3JkZXJJZHgrKykKICAgICAgICB7CiAgICAgICAgICAgIGNvbnN0IGJveGVzTmVlZGVkID0gcmVxdWVzdGVkT3JkZXJCb3hlc1tvcmRlcklkeF07CiAgICAgICAgICAgIGNvbnN0IG96TmVlZGVkID0gYm94ZXNOZWVkZWQgKiBib3hPdW5jZXM7CiAgICAgICAgICAgIGNvbnN0IHNpemVzQWxsb3dlZCA9IHJlcXVlc3RlZE9yZGVyU2l6ZXNbb3JkZXJJZHhdOwogICAgICAgICAgICBjb25zdCBzZWxlY3RlZEZpZWxkcyA9IG9yZGVyRmllbGRTZWxlY3Rpb25zW29yZGVySWR4XTsKCiAgICAgICAgICAgIC8vQ29weSBvdmVyIHN0b3JhZ2UgZnJvbSBsYXN0IG9yZGVyLCBpZiBhcHBsaWNhYmxlCiAgICAgICAgICAgIC8vKElmIHRoZXJlIGlzIG5vIHByZXZpb3VzIG9yZGVyLCB1c2UgdGhlIHN0YXJ0aW5nIHplcm9lZC1vdXQgYXJyYXkpCiAgICAgICAgICAgIC8vQ29udmVydCBmcm9tIGJveGVzIHRvIG91bmNlcy4gV2UnbGwgY29udmVydCBiYWNrIHRvIGJveGVzIGFuZCBkcm9wIGFueSBwYXJ0aWFsIGJveGVzIGF0IHRoZSBlbmQKICAgICAgICAgICAgc3RvcmFnZVN0YXRlUGVyT3JkZXJbb3JkZXJJZHhdID0gKChzdG9yYWdlU3RhdGVQZXJPcmRlcltvcmRlcklkeCAtIDFdKSA/PyBzdG9yYWdlU3RhdGVQZXJPcmRlcltvcmRlcklkeF0pLm1hcCgKICAgICAgICAgICAgICAgIChib3hlcykgPT4gKGJveGVzICogYm94T3VuY2VzKQogICAgICAgICAgICApOwogICAgICAgICAgICAvL1NlZSBpZiByZWxldmFudCBib3hlcyBhcmUgaW4gc3RvcmFnZSwKICAgICAgICAgICAgLy9hZGQgdG8gb3ogcGFja2VkIGFuZCByZW1vdmUgZnJvbSBzdG9yYWdlIGlmIHNvCiAgICAgICAgICAgIGZvcihsZXQgc2l6ZUlkeCA9IDA7IHNpemVJZHggPCBzaXplc0FsbG93ZWQubGVuZ3RoICYmIG96UGFja2VkUGVyT3JkZXJbb3JkZXJJZHhdIDwgb3pOZWVkZWQ7IHNpemVJZHgrKykKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgaWYoc2l6ZXNBbGxvd2VkW3NpemVJZHhdKQogICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgIGNvbnN0IG96VGFrZW5Gcm9tU3RvcmFnZSA9IE1hdGgubWluKG96TmVlZGVkIC0gb3pQYWNrZWRQZXJPcmRlcltvcmRlcklkeF0sIHN0b3JhZ2VTdGF0ZVBlck9yZGVyW29yZGVySWR4XVtzaXplSWR4XSk7CiAgICAgICAgICAgICAgICAgICAgc3RvcmFnZVN0YXRlUGVyT3JkZXJbb3JkZXJJZHhdW3NpemVJZHhdIC09IG96VGFrZW5Gcm9tU3RvcmFnZTsKICAgICAgICAgICAgICAgICAgICBvelBhY2tlZFBlck9yZGVyW29yZGVySWR4XSArPSBvelRha2VuRnJvbVN0b3JhZ2U7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIGlmKG9yZGVySWR4ICUgb3JkZXJzUGVyRGF5ID09IDApIHByZXZTZWxlY3RlZEZpZWxkID0gLTE7CgogICAgICAgICAgICAvL0xvb3AgdGhyb3VnaCBlYWNoIHNlbGVjdGVkIGZpZWxkLgogICAgICAgICAgICBmb3IobGV0IGkgPSAwOyBpIDwgc2VsZWN0ZWRGaWVsZHMubGVuZ3RoICYmIG96UGFja2VkUGVyT3JkZXJbb3JkZXJJZHhdIDwgb3pOZWVkZWQ7IGkrKykKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgY29uc3Qgc2VsZWN0ZWRGaWVsZElkeCA9IHNlbGVjdGVkRmllbGRzW2ldOwoKICAgICAgICAgICAgICAgIGlmKHNlbGVjdGVkRmllbGRJZHggPj0gMCkKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICBpZihwcmV2U2VsZWN0ZWRGaWVsZCAhPT0gLTEgJiYgc2VsZWN0ZWRGaWVsZElkeCAhPT0gcHJldlNlbGVjdGVkRmllbGQpCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICBmaWVsZFN3aXRjaENvdW50UGVyT3JkZXJbb3JkZXJJZHhdKys7CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHByZXZTZWxlY3RlZEZpZWxkID0gc2VsZWN0ZWRGaWVsZElkeDsKCiAgICAgICAgICAgICAgICAgICAgLy9TdGFydCBwYWNraW5nIGZyb20gdGhpcyBmaWVsZC4KICAgICAgICAgICAgICAgICAgICAvL0ZpcnN0IGluZGV4IHRvIHBhY2sgZnJvbSBpcyB0aGUgc3VtIG9mIGFsbCBwb3RhdG9lcyB0YWtlbiBmcm9tIHRoaXMgZmllbGQgYnkgcHJpb3Igb3JkZXJzCiAgICAgICAgICAgICAgICAgICAgbGV0IHN0YXJ0SWR4ID0gMDsKICAgICAgICAgICAgICAgICAgICBmb3IobGV0IHBhc3RPcmRlcklkeCA9IDA7IHBhc3RPcmRlcklkeCA8PSBvcmRlcklkeDsgcGFzdE9yZGVySWR4KyspCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICBzdGFydElkeCArPSBwb3RhdG9lc1Rha2VuRnJvbUVhY2hGaWVsZFBlck9yZGVyW3Bhc3RPcmRlcklkeF1bc2VsZWN0ZWRGaWVsZElkeF07CiAgICAgICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgICAgICBsZXQgcG90YXRvV2VpZ2h0cyA9IHJhd0ZpZWxkUG90YXRvRGF0YVtzZWxlY3RlZEZpZWxkSWR4XTsKCiAgICAgICAgICAgICAgICAgICAgZm9yKGxldCBwb3RhdG9JZHggPSBzdGFydElkeDsgcG90YXRvSWR4IDwgcG90YXRvV2VpZ2h0cy5sZW5ndGggJiYgb3pQYWNrZWRQZXJPcmRlcltvcmRlcklkeF0gPCBvek5lZWRlZDsgcG90YXRvSWR4KyspCiAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICBjb25zdCBwb3RhdG9PdW5jZXMgPSBwb3RhdG9XZWlnaHRzW3BvdGF0b0lkeF07CiAgICAgICAgICAgICAgICAgICAgICAgIGNvbnN0IHBvdGF0b1NpemVJZHggPSBnZXRTaXplSWR4Rm9yUG90YXRvKHBvdGF0b091bmNlcyk7CiAgICAgICAgICAgICAgICAgICAgICAgIGlmKHNpemVzQWxsb3dlZFtwb3RhdG9TaXplSWR4XSkKICAgICAgICAgICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICAgICAgICAgLy9QYWNrIGZvciB0aGlzIG9yZGVyCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBvelBhY2tlZFBlck9yZGVyW29yZGVySWR4XSArPSBwb3RhdG9PdW5jZXM7CiAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgZWxzZQogICAgICAgICAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAvL1B1dCBpbiBzdG9yYWdlCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBzdG9yYWdlU3RhdGVQZXJPcmRlcltvcmRlcklkeF1bcG90YXRvU2l6ZUlkeF0gKz0gcG90YXRvT3VuY2VzOwogICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgICAgIC8vQ291bnQgdG93YXJkIHdhZ2VzCiAgICAgICAgICAgICAgICAgICAgICAgIG96SGFydmVzdGVkUGVyT3JkZXJbb3JkZXJJZHhdICs9IHBvdGF0b091bmNlczsKCiAgICAgICAgICAgICAgICAgICAgICAgIHBvdGF0b2VzVGFrZW5Gcm9tRWFjaEZpZWxkUGVyT3JkZXJbb3JkZXJJZHhdW3NlbGVjdGVkRmllbGRJZHhdKys7CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgICAgIC8vU3RhcnQgYXQgaWR4ID0gc3VtIG9mIGFsbCBwb3RhdG9lcyBwYWNrZWQgZnJvbSB0aGlzIGZpZWxkIGR1cmluZyBwcmlvciBvcmRlcnMKICAgICAgICAgICAgLy9Gb3IgZWFjaCBwb3RhdG8sIGVpdGhlciBhZGQgaXRzIG91bmNlcyB0byB0aGUgcmVsZXZhbnQgc3RvcmFnZSBjYXRlZ29yeSwgb3IKICAgICAgICAgICAgLy90byBvelBhY2tlZFBlck9yZGVyLCB1bnRpbCBlbmQgb2YgZmllbGQgaXMgcmVhY2hlZCBvciBvelBhY2tlZFBlck9yZGVyW3RoaXNdID09IG96TmVlZGVkCiAgICAgICAgICAgIC8vKmJyZWFrKiBvbiBvelBhY2tlZFBlck9yZGVyW3RoaXNdID09IG96TmVlZGVkLgogICAgICAgICAgICAvL0lmIHdlIGRpZG4ndCBicmVhaywgYW5kIHdlJ3JlIG5vdCBvdXQgb2YgZmllbGQgc2VsZWN0aW9ucywgd2Ugc3dpdGNoZWQgZmllbGRzLiBmaWVsZFN3aXRjaENvdW50KysKCiAgICAgICAgICAgIC8vQ09OVkVSVCBzdG9yYWdlIGJhY2sgdG8gYm94ZXMgd2l0aCBNYXRoLmZsb29yKHN0b3JhZ2VWYWwgLyBib3hPdW5jZXMpLiBUaGlzIHdpbGwgdGlkaWx5IGRpc2NhcmQKICAgICAgICAgICAgLy9hbGwgcGFydGlhbCBib3hlcyBsaWtlIHdlIHdhbnQuCiAgICAgICAgICAgIHN0b3JhZ2VTdGF0ZVBlck9yZGVyW29yZGVySWR4XSA9IHN0b3JhZ2VTdGF0ZVBlck9yZGVyW29yZGVySWR4XS5tYXAoKHN0b3JlZE91bmNlcykgPT4gKE1hdGguZmxvb3Ioc3RvcmVkT3VuY2VzIC8gYm94T3VuY2VzKSkpOwogICAgICAgICAgICAvL0kgZ3Vlc3Mgd2UgY2FuIGxvb3AgdGhyb3VnaCBhbGwgb3VyIHN0b3JhZ2Ugc3RhdGVzIHRvIGZpZ3VyZSBzdG9yYWdlIGNvc3RzIGFmdGVyIHBhY2tpbmcgbG9vcCBpcyBkb25lPwoKICAgICAgICAgICAgLy8gY29uc29sZS5sb2coYFByb2Nlc3Npbmcgb3JkZXIgJHtpfSwgbmVlZCAke2JveGVzTmVlZGVkfSBib3hlcy4gQWNjZXB0ZWQgc2l6ZXM6ICR7U3RyaW5nKHNpemVzQWxsb3dlZCl9LiBGaWVsZHMgc2VsZWN0ZWQ6ICR7U3RyaW5nKHNlbGVjdGVkRmllbGRzKX1gKTsKICAgICAgICAgICAgCiAgICAgICAgfQoKICAgICAgICAvL0ZvciBlYWNoIGZpZWxkLCBjcmVhdGUgb25lIHNlcmllcyBwZXIgb3JkZXIsIGZvciB0aGUgbnVtYmVyIG9mIHBvdGF0b2VzIHRha2VuIG91dCBvZiB0aGF0IGZpZWxkIGJ5IHRoYXQgb3JkZXIKICAgICAgICAvL0VhY2ggb3JkZXIgdHJhY2tzIHRoZSBudW1iZXIgb2YgcG90YXRvZXMgaXQgcmVtb3ZlZCBmcm9tIGVhY2ggZmllbGQsIHNvIGFjY3VtdWxhdGUgdGhvc2UgdmFsdWVzIGFzIGluZGljZXMsCiAgICAgICAgLy9zdG9yZWQgaW4gZmllbGRSZXBvcnRJbmRpY2VzCiAgICAgICAgbGV0IGZpZWxkc0RhdGFPYmplY3RzID0gW107CiAgICAgICAgbGV0IGZpZWxkUmVwb3J0SW5kaWNlcyA9IHJhd0ZpZWxkUG90YXRvRGF0YS5tYXAoKCkgPT4gMCk7CiAgICAgICAgZm9yIChsZXQgZmllbGRJZHggPSAwOyBmaWVsZElkeCA8IHJhd0ZpZWxkUG90YXRvRGF0YS5sZW5ndGg7IGZpZWxkSWR4KyspCiAgICAgICAgewogICAgICAgICAgICBjb25zdCBwb3RhdG9XZWlnaHRMaXN0ID0gcmF3RmllbGRQb3RhdG9EYXRhW2ZpZWxkSWR4XTsgLy9SYXcgcG90YXRvIHdlaWdodHMgZm9yIHRoaXMgZmllbGQKCiAgICAgICAgICAgIC8vQ29uc3RydWN0IGEgQmFyQ2hhcnQgRGlzcGxheSdzIERhdGEgb2JqZWN0CiAgICAgICAgICAgIC8vRGlzcGxheSBwb3RhdG9lcyB0YWtlbiBmcm9tIGVhY2ggZmllbGQgYWNyb3NzIHRoZSBkaXN0cmlidXRpb24gb2YgcG90YXRvIHNpemVzCiAgICAgICAgICAgIGxldCBmaWVsZERhdGEgPSB7CiAgICAgICAgICAgICAgICB4QXhpc0xhYmVsczogc2l6ZUxhYmVscywKICAgICAgICAgICAgICAgIHNlcmllczogW10gIC8vUG9wdWxhdGUgaW4gdGhlIGZvciBsb29wIGJlbG93CiAgICAgICAgICAgIH07CgogICAgICAgICAgICBmb3IgKGxldCBvcmRlcklkeCA9IDA7IG9yZGVySWR4IDwgcG90YXRvZXNUYWtlbkZyb21FYWNoRmllbGRQZXJPcmRlci5sZW5ndGg7IG9yZGVySWR4KyspCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgIC8vQ29uc3RydWN0IHRoaXMgc2VyaWVzIGZyb20gdGhlIGxpc3Qgb2YgcG90YXRvIHdlaWdodHMgc3RhcnRpbmcgYXQgYmVnaW5JZHgsIGVuZGluZyBhdCBlbmRJZHgKICAgICAgICAgICAgICAgIGNvbnN0IGJlZ2luSWR4ID0gZmllbGRSZXBvcnRJbmRpY2VzW2ZpZWxkSWR4XTsKICAgICAgICAgICAgICAgIGNvbnN0IGVuZElkeCA9IGJlZ2luSWR4ICsgcG90YXRvZXNUYWtlbkZyb21FYWNoRmllbGRQZXJPcmRlcltvcmRlcklkeF1bZmllbGRJZHhdOwogICAgICAgICAgICAgICAgbGV0IGZpZWxkT3JkZXJTZXJpZXMgPSB7CiAgICAgICAgICAgICAgICAgICAgdGl0bGU6IGBQb3RhdG9lcyB0YWtlbiBmcm9tIGZpZWxkICR7ZmllbGRJZHh9IGZvciBvcmRlciAke29yZGVySWR4fWAsCiAgICAgICAgICAgICAgICAgICAgdmFsdWVzOiBtYWtlRmllbGRTZXJpZXNGcm9tUG90YXRvTGlzdChwb3RhdG9XZWlnaHRMaXN0LnNsaWNlKGJlZ2luSWR4LCBlbmRJZHgpKSwKICAgICAgICAgICAgICAgICAgICBjb2xvcjogb3JkZXJDb2xvcnNbb3JkZXJJZHggJSBvcmRlckNvbG9ycy5sZW5ndGhdCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBmaWVsZFJlcG9ydEluZGljZXNbZmllbGRJZHhdID0gZW5kSWR4OyAgLy9UaGUgaW5kZXggb2YgdGhlIGxhc3QgcG90YXRvIGFjY291bnRlZCBmb3IgaW4gdGhpcyBmaWVsZAogICAgICAgICAgICAgICAgZmllbGREYXRhLnNlcmllcy5wdXNoKGZpZWxkT3JkZXJTZXJpZXMpOwogICAgICAgICAgICB9CgogICAgICAgICAgICAvL1NwZWNpYWwgY2FzZTogUGxvdCB0aGUgcmVtYWluaW5nIGZpZWxkIHN0YXRlIGluIGdyZWVuIGF0IHRoZSBib3R0b20gb2YgdGhlIGJhciBjaGFydAogICAgICAgICAgICBsZXQgcmVtYWluaW5nSW5GaWVsZCA9IHsKICAgICAgICAgICAgICAgIHRpdGxlOiBgUG90YXRvZXMgcmVtYWluaW5nIGluIGZpZWxkICR7ZmllbGRJZHh9YCwKICAgICAgICAgICAgICAgIHZhbHVlczogbWFrZUZpZWxkU2VyaWVzRnJvbVBvdGF0b0xpc3QocG90YXRvV2VpZ2h0TGlzdC5zbGljZShmaWVsZFJlcG9ydEluZGljZXNbZmllbGRJZHhdKSksCiAgICAgICAgICAgICAgICBjb2xvcjogIiM5NWQ0OTEiCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZmllbGREYXRhLnNlcmllcy51bnNoaWZ0KHJlbWFpbmluZ0luRmllbGQpOwoKICAgICAgICAgICAgZmllbGRzRGF0YU9iamVjdHMucHVzaChmaWVsZERhdGEpOwogICAgICAgIH0KCiAgICAgICAgLy9DcmVhdGUgZGF0YSBvYmplY3RzIGZvciB0aGUgc3RvcmFnZSBzdGF0ZSBhZnRlciBlYWNoIG9yZGVyCiAgICAgICAgbGV0IHN0b3JhZ2VTdGF0ZXNEYXRhT2JqZWN0cyA9IFtdOwogICAgICAgIGxldCBib3hlc1N0b3JlZFBlck9yZGVyID0gW107ICAvL05lZWQgdG90YWwgYm94ZXMgaW4gc3RvcmFnZSBhZnRlciBlYWNoIG9yZGVyLCBmb3IgY2FsY3VsYXRpbmcgc3RvcmFnZSBjb3N0cwogICAgICAgIGxldCBzdG9yYWdlTWF4WSA9IDQwOwogICAgICAgIGZvcihsZXQgc3RvcmFnZUlkeCA9IDA7IHN0b3JhZ2VJZHggPCBzdG9yYWdlU3RhdGVQZXJPcmRlci5sZW5ndGg7IHN0b3JhZ2VJZHgrKykKICAgICAgICB7CiAgICAgICAgICAgIHN0b3JhZ2VTdGF0ZXNEYXRhT2JqZWN0cy5wdXNoKHsKICAgICAgICAgICAgICAgIHhBeGlzTGFiZWxzOiBzaXplTGFiZWxzLAogICAgICAgICAgICAgICAgc2VyaWVzOiBbewogICAgICAgICAgICAgICAgICAgIHRpdGxlOiBgU3RvcmFnZSBzdGF0ZSBhZnRlciBvcmRlciAke3N0b3JhZ2VJZHh9YCwKICAgICAgICAgICAgICAgICAgICB2YWx1ZXM6IHN0b3JhZ2VTdGF0ZVBlck9yZGVyW3N0b3JhZ2VJZHhdLAogICAgICAgICAgICAgICAgICAgIGNvbG9yOiBvcmRlckNvbG9yc1tzdG9yYWdlSWR4ICUgb3JkZXJDb2xvcnMubGVuZ3RoXQogICAgICAgICAgICAgICAgfV0KICAgICAgICAgICAgfSk7CiAgICAgICAgICAgIGJveGVzU3RvcmVkUGVyT3JkZXIucHVzaCgwKTsKICAgICAgICAgICAgc3RvcmFnZVN0YXRlUGVyT3JkZXJbc3RvcmFnZUlkeF0uZm9yRWFjaCgoYm94ZXNTdG9yZWQpID0+IHsKICAgICAgICAgICAgICAgIGNvbnN0IGJveGVzUm91bmRlZFVwQnkxMCA9IE1hdGguY2VpbChib3hlc1N0b3JlZCAvIDEwKSAqIDEwOwogICAgICAgICAgICAgICAgc3RvcmFnZU1heFkgPSBNYXRoLm1heChzdG9yYWdlTWF4WSwgYm94ZXNSb3VuZGVkVXBCeTEwKTsKCiAgICAgICAgICAgICAgICBib3hlc1N0b3JlZFBlck9yZGVyW3N0b3JhZ2VJZHhdICs9IGJveGVzU3RvcmVkOwogICAgICAgICAgICB9KTsKICAgICAgICB9CiAgICAgICAgLy9BZGp1c3QgdXBwZXIgYm91bmRzIGZvciBzdG9yYWdlIHkgYXhpcwogICAgICAgIGZvcihsZXQgc3RvcmFnZUlkeCA9IDA7IHN0b3JhZ2VJZHggPCBzdG9yYWdlU3RhdGVzRGF0YU9iamVjdHMubGVuZ3RoOyBzdG9yYWdlSWR4KyspCiAgICAgICAgewogICAgICAgICAgICBsZXQgZGF0YSA9IHN0b3JhZ2VTdGF0ZXNEYXRhT2JqZWN0c1tzdG9yYWdlSWR4XTsKICAgICAgICAgICAgZGF0YS5tYXhZID0gc3RvcmFnZU1heFk7CiAgICAgICAgfQoKICAgICAgICAvL0NvbnZlcnQgb3ogdG8gYm94ZXMKICAgICAgICBsZXQgYm94ZXNQYWNrZWRQZXJPcmRlciA9IFtdOwogICAgICAgIG96UGFja2VkUGVyT3JkZXIuZm9yRWFjaCgob3opID0+IGJveGVzUGFja2VkUGVyT3JkZXIucHVzaChNYXRoLmZsb29yKG96IC8gYm94T3VuY2VzKSkpOwoKICAgICAgICAvL0NhbGN1bGF0ZSBjb3N0IC8gcmV2ZW51ZQogICAgICAgIGNvbnN0IHdvcmtSYXRlUGVySG91ciA9IGRlY2lzaW9uQ29uZmlnLndvcmtSYXRlUGVySG91cjsKICAgICAgICBjb25zdCB3b3JrUmF0ZVBlck1pbnV0ZSA9IHdvcmtSYXRlUGVySG91ciAvIDYwOwogICAgICAgIGNvbnN0IG1pbnV0ZXNXb3JrZWRQZXJQb3VuZEhhcnZlc3RlZCA9IGRlY2lzaW9uQ29uZmlnLm1pbnV0ZXNXb3JrZWRQZXJQb3VuZEhhcnZlc3RlZDsKICAgICAgICBjb25zdCBmaWVsZFN3aXRjaEZsYXRDb3N0ID0gZGVjaXNpb25Db25maWcuZmllbGRTd2l0Y2hGbGF0Q29zdDsKICAgICAgICBjb25zdCBmaWVsZFN3aXRjaE1pbnV0ZXMgPSBkZWNpc2lvbkNvbmZpZy5maWVsZFN3aXRjaE1pbnV0ZXM7CiAgICAgICAgY29uc3Qgc3RvcmFnZUNvc3RQZXJCb3ggPSBkZWNpc2lvbkNvbmZpZy5zdG9yYWdlQ29zdFBlckJveDsKICAgICAgICBjb25zdCByZXZlbnVlUGVyQm94ID0gZGVjaXNpb25Db25maWcucmV2ZW51ZVBlckJveDsKCiAgICAgICAgbGV0IHJldmVudWVTZXJpZXMgPSBbXTsKICAgICAgICBsZXQgdG90YWxQcm9maXQgPSAwOwoKICAgICAgICBmb3IobGV0IG9yZGVySWR4ID0gMDsgb3JkZXJJZHggPCBib3hlc1N0b3JlZFBlck9yZGVyLmxlbmd0aDsgb3JkZXJJZHgrKykKICAgICAgICB7CiAgICAgICAgICAgIGNvbnN0IGZpZWxkU3dpdGNoZXMgPSBmaWVsZFN3aXRjaENvdW50UGVyT3JkZXJbb3JkZXJJZHhdOwogICAgICAgICAgICBjb25zdCBib3hlc1N0b3JlZCA9IGJveGVzU3RvcmVkUGVyT3JkZXJbb3JkZXJJZHhdOwogICAgICAgICAgICBjb25zdCBsYnNIYXJ2ZXN0ZWQgPSBvekhhcnZlc3RlZFBlck9yZGVyW29yZGVySWR4XSAvIDE2OwoKICAgICAgICAgICAgY29uc3Qgc3dpdGNoQ29zdCA9IGZpZWxkU3dpdGNoZXMgKiBmaWVsZFN3aXRjaEZsYXRDb3N0OyAvL0ZsYXQgY29zdCBvbmx5LiBXYWdlcyBpbmN1cnJlZCBmcm9tIHN3aXRjaGluZyBhcmUgaW5jbHVkZWQgaW4gd2FnZXNDb3N0CiAgICAgICAgICAgIGNvbnN0IHN0b3JhZ2VDb3N0ID0gKChvcmRlcklkeCArIDEpICUgb3JkZXJzUGVyRGF5ID09IDAgfHwgIXN0b3JhZ2VDb3N0SXNQZXJEYXkgLy9Pbmx5IGluY3VyIG9uIHRoZSBsYXN0IG9yZGVyIG9mIHRoZSBkYXksIHVubGVzcyBzdG9yYWdlQ29zdElzUGVyRGF5ID09IGZhbHNlCiAgICAgICAgICAgICAgICA/IChib3hlc1N0b3JlZCAqIHN0b3JhZ2VDb3N0UGVyQm94KQogICAgICAgICAgICAgICAgOiAwKTsKICAgICAgICAgICAgY29uc3Qgd2FnZXNDb3N0ID0gKAogICAgICAgICAgICAgICAgKGxic0hhcnZlc3RlZCAqIG1pbnV0ZXNXb3JrZWRQZXJQb3VuZEhhcnZlc3RlZCAqIHdvcmtSYXRlUGVyTWludXRlKSAvL0luY2x1ZGVzIHdhZ2VzIGZvciBwYWNraW5nIHVuZmluaXNoZWQgYm94ZXMKICAgICAgICAgICAgICAgICsgKGZpZWxkU3dpdGNoZXMgKiBmaWVsZFN3aXRjaE1pbnV0ZXMgKiB3b3JrUmF0ZVBlck1pbnV0ZSkgICAgICAgICAgLy9XYWdlcyBmcm9tIGZpZWxkIHN3aXRjaGluZwogICAgICAgICAgICApOwogICAgICAgICAgICBjb25zdCByZXZlbnVlID0gYm94ZXNQYWNrZWRQZXJPcmRlcltvcmRlcklkeF0gPj0gcmVxdWVzdGVkT3JkZXJCb3hlc1tvcmRlcklkeF0KICAgICAgICAgICAgICAgID8gYm94ZXNQYWNrZWRQZXJPcmRlcltvcmRlcklkeF0gKiByZXZlbnVlUGVyQm94IC8vRE9FUyBOT1QgaW5jbHVkZSB1bmZpbmlzaGVkIGJveGVzCiAgICAgICAgICAgICAgICA6IDA7IC8vRG9uJ3QgZ2V0IHJldmVudWUgZnJvbSBpbmNvbXBsZXRlIG9yZGVycwoKICAgICAgICAgICAgY29uc3Qgb3JkZXJDb2xvciA9IG9yZGVyQ29sb3JzW29yZGVySWR4ICUgb3JkZXJDb2xvcnMubGVuZ3RoXTsKCiAgICAgICAgICAgIHRvdGFsUHJvZml0ICs9IChyZXZlbnVlIC0gc3dpdGNoQ29zdCAtIHN0b3JhZ2VDb3N0IC0gd2FnZXNDb3N0KTsKCiAgICAgICAgICAgIHJldmVudWVTZXJpZXMucHVzaCh7CiAgICAgICAgICAgICAgICB0aXRsZTogYENvc3QvUmV2ZW51ZSBzcGxpdCBmb3Igb3JkZXIgJHtvcmRlcklkeH1gLAogICAgICAgICAgICAgICAgdmFsdWVzOiBbc3dpdGNoQ29zdCwgc3RvcmFnZUNvc3QsIHdhZ2VzQ29zdCwgcmV2ZW51ZV0sCiAgICAgICAgICAgICAgICBjb2xvcjogb3JkZXJDb2xvcgogICAgICAgICAgICB9KTsKICAgICAgICB9CgogICAgICAgIGNvbnN0IHByb2ZpdFN0cmluZyA9IGBcJCR7dG90YWxQcm9maXQudG9GaXhlZCgyKX1gOwoKICAgICAgICBsZXQgdG90YWxCb3hlc1JlcXVlc3RlZCA9IDA7CiAgICAgICAgcmVxdWVzdGVkT3JkZXJCb3hlcy5mb3JFYWNoKChib3hlcykgPT4gKHRvdGFsQm94ZXNSZXF1ZXN0ZWQgKz0gYm94ZXMpKTsKICAgICAgICBjb25zdCBtYXhSZXZlbnVlID0gdG90YWxCb3hlc1JlcXVlc3RlZCAqIHJldmVudWVQZXJCb3g7CgogICAgICAgIGxldCByZXZlbnVlID0gewogICAgICAgICAgICB4QXhpc0xhYmVsczogWyJDLiBTd2kiLCAiQy4gU3RvIiwgIkMuIFdhZyIsICJSZXZlbnVlIl0sCiAgICAgICAgICAgIHNlcmllczogcmV2ZW51ZVNlcmllcywKICAgICAgICAgICAgbWF4WTogTWF0aC5jZWlsKG1heFJldmVudWUgLyA1MCkgKiA1MCAgIC8vTWF4IHJldmVudWUgaW4gaW5jcmVtZW50cyBvZiA1MAogICAgICAgIH0KCiAgICAgICAgLy8gY29uc29sZS5sb2coImZkbyIsIGZpZWxkc0RhdGFPYmplY3RzLCAib3BwbyIsIG96UGFja2VkUGVyT3JkZXIsICJicHBvIiwgYm94ZXNQYWNrZWRQZXJPcmRlciwgInNzZG8iLCBzdG9yYWdlU3RhdGVzRGF0YU9iamVjdHMsICJyIiwgcmV2ZW51ZSwgInByIiwgcHJvZml0U3RyaW5nKTsKICAgICAgICAvLyBjb25zb2xlLmxvZygiRU5EIFBBQ0tJTkcgU0lNIik7CgogICAgICAgIC8vUmV0dXJucwogICAgICAgIC8vIFswXS1bN106IEJhckdyYXBoIGRhdGEgb2JqZWN0cyBmb3IgZWFjaCBmaWVsZCBpbiBvcmRlciBGaWVsZDEuLi5GaWVsZDgKICAgICAgICAvLyBbOF0tWzExXTogUmVwb3J0IG9mIHRoZSBib3hlcyBwYWNrZWQgZm9yIGVhY2ggb3JkZXIsIGZyb20gT3JkZXIxLi4uT3JkZXI0CiAgICAgICAgLy8gWzEyXS1bMTVdOiBSZXBvcnQgb2Ygc3RvcmFnZSBzdGF0ZSBhZnRlciBlYWNoIG9yZGVyCiAgICAgICAgLy8gWzE2XTogUmVwb3J0IG9mIHJldmVudWUvY29zdCBzcGxpdCBwZXIgb3JkZXIgKHN0YWNrZWQgc28geW91IGNhbiBzZWUgdG90YWxzKQogICAgICAgIC8vIFsxN106IFRvdGFsIHByb2ZpdCBhZnRlciBhbGwgcGFja2luZyBpcyBmaW5pc2hlZCwgYXMgYSBzdHJpbmdpZmllZCBkb2xsYXIgYW1vdW50CiAgICAgICAgcmV0dXJuIFsuLi5maWVsZHNEYXRhT2JqZWN0cywgLi4uYm94ZXNQYWNrZWRQZXJPcmRlciwgLi4uc3RvcmFnZVN0YXRlc0RhdGFPYmplY3RzLCByZXZlbnVlLCBwcm9maXRTdHJpbmddOwogICAgfQoKICAgIC8vTUFQIFlPVVIgRlVOQ1RJT04gVE8gQSBTVFJJTkcgTkFNRSBIRVJFOgogICAgcmV0dXJuIHsgZnVuY01hcDogeyJzaW11bGF0ZVBhY2tpbmciOiBzaW11bGF0ZVBhY2tpbmd9IH07Cgp9KSgpOwoKCi8vIFRvIGltcG9ydCBhIHNjcmlwdCwgaXQgbXVzdCB1c2UgYSBzaW1pbGFyIHN0cnVjdHVyZSB0byB0aGUgZXhhbXBsZSBjb2RlIGFib3ZlLiBJdCBzaG91bGQgdGFrZSB0aGUgZm9ybSBvZgovLyBhbiBpbW1lZGlhdGVseSBpbnZva2VkIGZ1bmN0aW9uIGV4cHJlc3Npb246IGh0dHBzOi8vZGV2ZWxvcGVyLm1vemlsbGEub3JnL2VuLVVTL2RvY3MvR2xvc3NhcnkvSUlGRSB3aGVyZSB0aGUKLy8gZnVuY3Rpb24gcmV0dXJucyBhIGZ1bmN0aW9uIG1hcCBjYWxsZWQgZnVuY01hcC4KLy8gCi8vIGZ1bmNNYXAgc2hvdWxkIGhhdmUgc3RyaW5nIGtleXMgYW5kIGZ1bmN0aW9uIHZhbHVlcy4gU3RyaW5nIGtleXMgd2lsbCBiZSB1c2VkIGJ5IEV2YWx1YXRhYmxlIEVsZW1lbnRzCi8vIHRvIHBhc3MgaW5wdXRzIHRvIGFuZCByZWNlaXZlIG91dHB1dHMgZnJvbSB0aGUgZnVuY3Rpb25zLgovLyAKLy8gRWFjaCBzY3JpcHQgbWF5IGRlZmluZSBhcmJpdHJhcmlseSBtYW55IGZ1bmN0aW9ucywgc28gbG9uZyBhcyB0aGV5J3JlIGFsbCBleHBvc2VkIHZpYSBmdW5jTWFwLgovLyAKLy8gRnVuY3Rpb24gaW5wdXRzIHdpbGwgdGFrZSB0aGUgZm9ybSBvZiBhIHNpbmdsZSBhcnJheSBvZiA8YW55PiB2YWx1ZXMuCi8vIEZ1bmN0aW9ucyBzaG91bGQgbGlrZXdpc2UgcmV0dXJuIGFuIGFycmF5IG9mIDxhbnk+IHZhbHVlcy4KLy8gTWVhbmluZyBmb3IgYXJndW1lbnRzIGFuZCByZXR1cm4gdmFsdWVzIGlzIGRldGVybWluZWQgYnkgdGhlaXIgb3JkZXIgaW4gdGhlIGFycmF5Lg=="
+            }
+        },
+        {
+            "meta": {
+                "uuid": "93218b32-cf62-4e6d-b681-aa09a9605ba7",
+                "name": "Process Various Inputs"
+            },
+            "evalType": "Script",
+            "content": {
+                "language": "javascript",
+                "script": "KGZ1bmN0aW9uICgpIHsKCiAgICBjb25zdCBjcmVhdGVBUElFbmRwb2ludEV4dGVuc2lvbiA9IGZ1bmN0aW9uKGlucHV0cykgewogICAgICAgIC8vSG93IHRvIHNldCB1cCBhIGtleTogaHR0cHM6Ly9zdXBwb3J0Lmdvb2dsZS5jb20vZ29vZ2xlYXBpL2Fuc3dlci82MTU4ODYyCiAgICAgICAgY29uc3QgYXBpS2V5ID0gaW5wdXRzWzBdOwoKICAgICAgICAvL0hlcmUgImZpZWxkIiBtZWFucyBhIEpTT04gcGF0aCBrZXkKICAgICAgICAvL2h0dHBzOi8vZGV2ZWxvcGVycy5nb29nbGUuY29tL3dvcmtzcGFjZS9zaGVldHMvYXBpL2d1aWRlcy9maWVsZC1tYXNrcwogICAgICAgIGNvbnN0IGZpZWxkTWFzayA9ICJzaGVldHMocHJvcGVydGllcy50aXRsZSxkYXRhLnJvd0RhdGEudmFsdWVzLmVmZmVjdGl2ZVZhbHVlLm51bWJlclZhbHVlKSI7CiAgICAgICAgLy9UaGVyZSdzIGEgbG90IG1vcmUgc3ByZWFkc2hlZXQgaW5mby9kYXRhIHdlICpjb3VsZCogcHVsbCwgYnV0IHdlIGRvbid0IG5lZWQgaXQKCiAgICAgICAgLy9IZXJlICJmaWVsZCIgbWVhbnMgYSBsaXRlcmFsIGZpZWxkIG9mIHN3ZWV0IHBvdGF0b2VzCiAgICAgICAgLy9FYWNoIHBvdGF0byBmaWVsZCBzdG9yZXMgYSBsaXN0IG9mIHdlaWdodHMgaW4gdGhlIHNhbWUgY2VsbCByYW5nZQogICAgICAgIC8vQjM6QjEyNzUgaW4gQTEgbm90YXRpb24gaHR0cHM6Ly9kZXZlbG9wZXJzLmdvb2dsZS5jb20vd29ya3NwYWNlL3NoZWV0cy9hcGkvZ3VpZGVzL2NvbmNlcHRzI2NlbGwgd2l0aCBVUkwgZW5jb2RpbmcgZm9yIGNvbG9uIHN5bWJvbCBodHRwczovL3d3dy53M3NjaG9vbHMuY29tL3RhZ3MvcmVmX3VybGVuY29kZS5BU1AKICAgICAgICBjb25zdCBwb3RhdG9XZWlnaHRzUmFuZ2UgPSAiQjMlM0FCMTI3NSI7CiAgICAgICAgbGV0IGZpZWxkV2VpZ2h0TGlzdHMgPSAiIjsgLy9XaWxsIGhvbGQgcXVlcnkgcGFyYW1ldGVycyBmb3IgdGhlIGNlbGwgcmFuZ2VzIGZvciBwb3RhdG9lcyBpbiBhbGwgOCBmaWVsZHMKICAgICAgICBmb3IobGV0IGZpZWxkTnVtID0gMTsgZmllbGROdW0gPD0gODsgZmllbGROdW0rKykKICAgICAgICB7CiAgICAgICAgICAgIGZpZWxkV2VpZ2h0TGlzdHMgKz0gYCZyYW5nZXM9RmllbGQke2ZpZWxkTnVtfSEke3BvdGF0b1dlaWdodHNSYW5nZX1gOwogICAgICAgIH0KCiAgICAgICAgLy9FeGFtcGxlOiBgP2tleT0tLS0tLS0tLS0tLS0tQVBJIEtFWSAgSEVSRS0tLS0tLS0tLS0tLS0mZmllbGRzPXNoZWV0cyhwcm9wZXJ0aWVzLnRpdGxlLGRhdGEucm93RGF0YS52YWx1ZXMuZWZmZWN0aXZlVmFsdWUubnVtYmVyVmFsdWUpJnJhbmdlcz1GaWVsZDEhQjMlM0FCMTI3NSZyYW5nZXM9RmllbGQyIUIzJTNBQjEyNzUmcmFuZ2VzPUZpZWxkMyFCMyUzQUIxMjc1JnJhbmdlcz1GaWVsZDQhQjMlM0FCMTI3NSZyYW5nZXM9RmllbGQ1IUIzJTNBQjEyNzUmcmFuZ2VzPUZpZWxkNiFCMyUzQUIxMjc1JnJhbmdlcz1GaWVsZDchQjMlM0FCMTI3NSZyYW5nZXM9RmllbGQ4IUIzJTNBQjEyNzVgCiAgICAgICAgY29uc3QgZmluYWxVUklFeHRlbnNpb24gPSBgP2tleT0ke2FwaUtleX0mZmllbGRzPSR7ZmllbGRNYXNrfSR7ZmllbGRXZWlnaHRMaXN0c31gOwoKICAgICAgICByZXR1cm4gW2ZpbmFsVVJJRXh0ZW5zaW9uXTsKICAgIH0KCiAgICBjb25zdCBjaGVja0FQSUtleUZvdW5kID0gZnVuY3Rpb24oaW5wdXRzKSB7CiAgICAgICAgY29uc3QgYXBpS2V5ID0gaW5wdXRzWzBdOwoKICAgICAgICBsZXQgb3V0ID0gIkFQSSBLRVkgTkVFREVEISBTZWUgbW9kZWwgc3VtbWFyeS4iCiAgICAgICAgaWYoYXBpS2V5ICE9PSBudWxsICYmIGFwaUtleSAhPT0gIiIpCiAgICAgICAgewogICAgICAgICAgICBvdXQgPSAiS2V5IGRldGVjdGVkISBQcm9ibGVtcz8gQ2hlY2sgY29uc29sZSwgb3IgcmVmcmVzaCBhbmQgcmV0cnkuIgogICAgICAgIH0KCiAgICAgICAgcmV0dXJuIFtvdXRdOwogICAgfQoKICAgIGNvbnN0IHByb2Nlc3NGaWVsZEpTT04gPSBmdW5jdGlvbiAoaW5wdXRzKSB7CiAgICAgICAgY29uc3QgcmF3RGF0YUpTT04gPSBpbnB1dHNbMF07CgogICAgICAgIC8vRmllbGQgbGFiZWwgc3RyaW5ncyB0YWtlIHRoZSBmb3JtYXQgIkZpZWxkTiIsIGFuZCB3ZSB3YW50IE4gYXMgYSBudW1iZXIuCiAgICAgICAgLy9MYWJlbCBzdHJpbmdzIGFyZSBub3QgMC1iYXNlZCwgc28gYWRqdXN0IGZvciBpbmRleAogICAgICAgIGNvbnN0IGV4dHJhY3RGaWVsZEluZGV4ID0gKGZpZWxkTGFiZWwpID0+IHsKICAgICAgICAgICAgY29uc3QgbGFiZWxBc1N0cmluZyA9IFN0cmluZyhmaWVsZExhYmVsKTsKICAgICAgICAgICAgcmV0dXJuIE51bWJlcihsYWJlbEFzU3RyaW5nLmNoYXJBdChsYWJlbEFzU3RyaW5nLmxlbmd0aCAtIDEpKSAtIDE7CiAgICAgICAgfQoKICAgICAgICBsZXQgcmF3RGF0YSA9IFtbXSwgW10sIFtdLCBbXSwgW10sIFtdLCBbXSwgW11dOwoKICAgICAgICBmb3IgKGNvbnN0IGZpZWxkU2hlZXQgb2YgcmF3RGF0YUpTT04uc2hlZXRzKQogICAgICAgIHsKICAgICAgICAgICAgY29uc3QgZmllbGRJZHggPSBleHRyYWN0RmllbGRJbmRleChmaWVsZFNoZWV0LnByb3BlcnRpZXMudGl0bGUpOwogICAgICAgICAgICBjb25zdCBmaWVsZERhdGEgPSBbXTsKICAgICAgICAgICAgZm9yKGNvbnN0IHBvdGF0b0pTT04gb2YgZmllbGRTaGVldC5kYXRhWzBdLnJvd0RhdGEpCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgIGZpZWxkRGF0YS5wdXNoKE51bWJlcihwb3RhdG9KU09OLnZhbHVlc1swXS5lZmZlY3RpdmVWYWx1ZS5udW1iZXJWYWx1ZSkpOwogICAgICAgICAgICB9CgogICAgICAgICAgICByYXdEYXRhW2ZpZWxkSWR4XSA9IGZpZWxkRGF0YTsKICAgICAgICB9CgogICAgICAgIC8vY29uc29sZS5sb2cocmF3RGF0YSk7CiAgICAgICAgCiAgICAgICAgcmV0dXJuIFtyYXdEYXRhXTsKICAgIH0KCiAgICBjb25zdCBnZXRSZXF1ZXN0ZWRPcmRlclNpemVzID0gZnVuY3Rpb24gKGlucHV0cykgewogICAgICAgIC8vVGFrZSB0aGUgZW50aXJlIGxpc3Qgb2YgcmF3IG9yZGVyIHNpemUgZmxhZ3MgZm9yIGFsbCBvcmRlcnMsCiAgICAgICAgLy9hbmQgY29uc3RydWN0IGEgbGlzdCBvZiBsaXN0cyB0aGF0J3MgZWFzaWVyIHRvIG5hdmlnYXRlLgogICAgICAgIC8vCiAgICAgICAgLy8gQXNzdW1wdGlvbnM6ICgxKSBXZSBnb3QgYWxsIG9mIHRoZSBvcmRlciBzaXplIGZsYWdzICgyKSBUaGV5J3JlIGFsbCBpbiB0aGUgb3JkZXIgWyJTIiwgIk0iLCAiTDEiLCAiTDIiLCAiWEwiLCAiRyJdCiAgICAgICAgLy8gKDMpIFdlIGtub3cgdGhlIHRvdGFsIG51bWJlciBvZiBvcmRlcnMgYW5kIHRoZSBudW1iZXIgb2YgcG9zc2libGUgc2l6ZXMgZm9yIGVhY2ggb3JkZXIuIEknbSBoYXJkLWNvZGluZyB0aGVzZQogICAgICAgIC8vIHZhbHVlcyBoZXJlLgoKICAgICAgICBjb25zdCBudW1PcmRlcnMgPSA0OwogICAgICAgIGNvbnN0IG51bVNpemVzID0gNjsKICAgICAgICBsZXQgcmVxdWVzdGVkT3JkZXJTaXplcyA9IFtdOwogICAgICAgIGZvciAobGV0IGkgPSAwOyBpIDwgbnVtT3JkZXJzOyBpKyspCiAgICAgICAgewogICAgICAgICAgICAvL1RoaXMgd2lsbCBwcm9kdWNlIGEgc2ltcGxlIGFycmF5IG9mIGZsYWdzIGZvciB0aGlzIG9yZGVyLCBjb3JyZXNwb25kaW5nIHRvIGVhY2ggYWxsb3dlZCBzaXplCiAgICAgICAgICAgIC8vZS5nLiBbZmFsc2UsIGZhbHNlLCB0cnVlLCBmYWxzZSwgdHJ1ZSwgZmFsc2VdIGZvciBhbiBvcmRlciB3aGVyZSBvbmx5IEwxIGFuZCBYTCBzaXplcyBhcmUgYWxsb3dlZC4KICAgICAgICAgICAgbGV0IHRoaXNPcmRlclJlcXVlc3RlZFNpemVzID0gW107CiAgICAgICAgICAgIGZvcihsZXQgaiA9IDA7IGogPCBudW1TaXplczsgaisrKQogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICB0aGlzT3JkZXJSZXF1ZXN0ZWRTaXplcy5wdXNoKGlucHV0c1soaSAqIG51bVNpemVzKSArIGpdKTsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgcmVxdWVzdGVkT3JkZXJTaXplcy5wdXNoKHRoaXNPcmRlclJlcXVlc3RlZFNpemVzKTsKICAgICAgICB9CgogICAgICAgIC8vU28gcmVxdWVzdGVkT3JkZXJTaXplc1swXSB3aWxsIGJlIHRoZSBsaXN0IG9mIGZsYWdzIChzZWUgYWJvdmUgZm9yIGV4YW1wbGUpIGZvciBhbGxvd2VkIHNpemVzIGZvciB0aGUgZmlyc3Qgb3JkZXIKICAgICAgICByZXR1cm4gW3JlcXVlc3RlZE9yZGVyU2l6ZXNdOwogICAgfQoKICAgIGNvbnN0IGdldFJlcXVlc3RlZEJveGVzUGVyT2RlciA9IGZ1bmN0aW9uKGlucHV0cykgewogICAgICAgIC8vV2UnbGwgZ2V0IHRoZXNlIGFzIGluZGl2aWR1YWwgbnVtYmVycywgY29tYmluZWQgaW50byB0aGUgbGlzdCBvZiBpbnB1dHMKICAgICAgICAvLy4ud2UganVzdCB3YW50IHRvIGJlIGFibGUgdG8gcmVmZXJlbmNlIHRoZXNlIGZyb20gd2l0aGluIGEgbGlzdCwgc28KICAgICAgICAvL2p1c3QgcmV0dXJuIHRoZSBpbnB1dHMgbGlzdCEKICAgICAgICByZXR1cm4gW2lucHV0c10KICAgIH0KCiAgICBjb25zdCBnZXRGaWVsZFNlbGVjdGlvbnNGb3JBbGxPcmRlcnMgPSBmdW5jdGlvbihpbnB1dHMpIHsKICAgICAgICAvL0NvbWJpbmUgaW5kaXZpZHVhbCBvcmRlciBmaWVsZCBzZWxlY3Rpb25zIGludG8gYSBzaW5nbGUgMkQgYXJyYXkgZm9yIGVhc2llciBpbmRleGluZwogICAgICAgIGNvbnN0IHNlbGVjdGlvbnNQZXJPcmRlciA9IDM7CiAgICAgICAgY29uc3Qgb3JkZXJTZWxlY3Rpb25zID0gW107CiAgICAgICAgbGV0IHNlbGVjdGlvbnNJblRoaXNPcmRlciA9IFtdOwogICAgICAgIGZvcihsZXQgc2VsZWN0aW9uSWR4ID0gMDsgc2VsZWN0aW9uSWR4IDwgaW5wdXRzLmxlbmd0aDsgc2VsZWN0aW9uSWR4KyspCiAgICAgICAgewogICAgICAgICAgICBzZWxlY3Rpb25zSW5UaGlzT3JkZXIucHVzaChOdW1iZXIoaW5wdXRzW3NlbGVjdGlvbklkeF0pIC0gMSk7CiAgICAgICAgICAgIGlmKHNlbGVjdGlvbnNJblRoaXNPcmRlci5sZW5ndGggPj0gc2VsZWN0aW9uc1Blck9yZGVyKQogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICBvcmRlclNlbGVjdGlvbnMucHVzaChbLi4uc2VsZWN0aW9uc0luVGhpc09yZGVyXSk7CiAgICAgICAgICAgICAgICBzZWxlY3Rpb25zSW5UaGlzT3JkZXIgPSBbXTsKICAgICAgICAgICAgfQogICAgICAgIH0KICAgICAgICBpZihzZWxlY3Rpb25zSW5UaGlzT3JkZXIubGVuZ3RoID4gMCkKICAgICAgICB7CiAgICAgICAgICAgIG9yZGVyU2VsZWN0aW9ucy5wdXNoKFsuLi5zZWxlY3Rpb25zSW5UaGlzT3JkZXJdKTsKICAgICAgICB9CgogICAgICAgIC8vIGNvbnNvbGUubG9nKG9yZGVyU2VsZWN0aW9ucyk7CgogICAgICAgIHJldHVybiBbb3JkZXJTZWxlY3Rpb25zXTsKICAgIH0KCiAgICBjb25zdCBnZXREZWNpc2lvbkNvbmZpZyA9IGZ1bmN0aW9uKGlucHV0cyl7CiAgICAgICAgLy9KdXN0IHR1cm4gdGhpcyBpbnRvIGFuIG9iamVjdCB3aXRoIG5hbWVkIGZpZWxkcwogICAgICAgIGNvbnN0IG91dCA9IHsKICAgICAgICAgICAgd29ya1JhdGVQZXJIb3VyOiBOdW1iZXIoaW5wdXRzWzBdKSwKICAgICAgICAgICAgbWludXRlc1dvcmtlZFBlclBvdW5kSGFydmVzdGVkOiBOdW1iZXIoaW5wdXRzWzFdKSwKICAgICAgICAgICAgZmllbGRTd2l0Y2hGbGF0Q29zdDogTnVtYmVyKGlucHV0c1syXSksCiAgICAgICAgICAgIGZpZWxkU3dpdGNoTWludXRlczogTnVtYmVyKGlucHV0c1szXSksCiAgICAgICAgICAgIHN0b3JhZ2VDb3N0UGVyQm94OiBOdW1iZXIoaW5wdXRzWzRdKSwKICAgICAgICAgICAgcmV2ZW51ZVBlckJveDogTnVtYmVyKGlucHV0c1s1XSksCiAgICAgICAgICAgIG9yZGVyc1BlckRheTogTWF0aC5mbG9vcihOdW1iZXIoaW5wdXRzWzZdKSksIC8vRm9yY2UgaW50CiAgICAgICAgICAgIHN0b3JhZ2VDb3N0SXNQZXJEYXk6IChpbnB1dHNbN10gPT0gIlBlci1kYXkiKSwgLy9Gb3JjZSBib29sCiAgICAgICAgfTsKICAgICAgICByZXR1cm4gW291dF07CiAgICB9CgogICAgY29uc3QgcG9wdWxhdGVPcmRlckluZm9TdHJpbmdzID0gZnVuY3Rpb24oaW5wdXRzKSB7CiAgICAgICAgLy9HZW5lcmF0ZSBhbiAib3JkZXIgaW5mbyBzdHJpbmciIGZvciBlYWNoIG9yZGVyCiAgICAgICAgLy9Gcm9tIHRoZSBsaXN0IG9mIHJlcXVlc3RlZCBwb3RhdG8gc2l6ZSBmbGFncyBmb3IgZWFjaCBvcmRlciwgYW5kIHRoZSBsaXN0CiAgICAgICAgLy9vZiB0aGUgbnVtYmVyIG9mIGJveGVzIHJlcXVlc3RlZCBmb3IgZWFjaCBvcmRlcgogICAgICAgIGNvbnN0IHJlcXVlc3RlZFNpemVzUGVyT3JkZXIgPSBpbnB1dHNbMF07IC8vUmVzdWx0IG9mIGdldFJlcXVlc3RlZE9yZGVyU2l6ZXMKICAgICAgICBjb25zdCBudW1Cb3hlc1Blck9yZGVyID0gaW5wdXRzWzFdOyAvL1Jlc3VsdCBvZiBnZXRSZXF1ZXN0ZWRCb3hlc1Blck9yZGVyCgogICAgICAgIGNvbnN0IHBvdGF0b1NpemVMYWJlbHMgPSBbIlMiLCAiTSIsICJMMSIsICJMMiIsICJYTCIsICJHIl07CgogICAgICAgIGxldCBvcmRlckluZm9TdHJpbmdzID0gW107CiAgICAgICAgZm9yKGxldCBvcmRlcklkeCA9IDA7IG9yZGVySWR4IDwgcmVxdWVzdGVkU2l6ZXNQZXJPcmRlci5sZW5ndGggJiYgb3JkZXJJZHggPCBudW1Cb3hlc1Blck9yZGVyLmxlbmd0aDsgb3JkZXJJZHgrKykKICAgICAgICB7CiAgICAgICAgICAgIGxldCBpbmZvU3RyaW5nID0gIkJveGVzOiAiICsgU3RyaW5nKG51bUJveGVzUGVyT3JkZXJbb3JkZXJJZHhdKSArICIgU2l6ZXM6ICI7CgogICAgICAgICAgICAvL1BvcHVsYXRlIGxpc3Qgb2YgYWxsb3dlZCBzaXplcyBmb3IgdGhpcyBvcmRlcgogICAgICAgICAgICBjb25zdCByZXF1ZXN0ZWRTaXplc1RoaXNPcmRlciA9IHJlcXVlc3RlZFNpemVzUGVyT3JkZXJbb3JkZXJJZHhdOwogICAgICAgICAgICBsZXQgdGhpc09yZGVyUmVxdWVzdGVkU29tZVNpemVzID0gZmFsc2U7CiAgICAgICAgICAgIGZvcihsZXQgc2l6ZUlkeCA9IDA7IHNpemVJZHggPCByZXF1ZXN0ZWRTaXplc1RoaXNPcmRlci5sZW5ndGg7IHNpemVJZHgrKykKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgaWYocmVxdWVzdGVkU2l6ZXNUaGlzT3JkZXJbc2l6ZUlkeF0pCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgaW5mb1N0cmluZyArPSBwb3RhdG9TaXplTGFiZWxzW3NpemVJZHhdICsgIiwgIjsKICAgICAgICAgICAgICAgICAgICB0aGlzT3JkZXJSZXF1ZXN0ZWRTb21lU2l6ZXMgPSB0cnVlOwogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CgogICAgICAgICAgICBpZighdGhpc09yZGVyUmVxdWVzdGVkU29tZVNpemVzKSB7aW5mb1N0cmluZyArPSAiKE5vbmUgU2VsZWN0ZWQpIn0KICAgICAgICAgICAgZWxzZQogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICBpbmZvU3RyaW5nID0gaW5mb1N0cmluZy5zbGljZSgwLCBpbmZvU3RyaW5nLmxlbmd0aCAtIDIpOyAvL1JlbW92ZSBsYXN0IGluc3RhbmNlIG9mICIsICIKICAgICAgICAgICAgfQoKICAgICAgICAgICAgb3JkZXJJbmZvU3RyaW5ncy5wdXNoKGluZm9TdHJpbmcpOwogICAgICAgIH0KCgogICAgICAgIC8vV2Ugd2FudCBlYWNoIG9yZGVyIGluZm8gc3RyaW5nIHRvIG1hcCB0byBpdHMgb3duIEkvTyB2YWx1ZQogICAgICAgIHJldHVybiBbLi4ub3JkZXJJbmZvU3RyaW5nc107CiAgICB9CgogICAgLy9NQVAgWU9VUiBGVU5DVElPTiBUTyBBIFNUUklORyBOQU1FIEhFUkU6CiAgICByZXR1cm4geyBmdW5jTWFwOiB7CiAgICAgICAgImNyZWF0ZUFQSUVuZHBvaW50RXh0ZW5zaW9uIjogY3JlYXRlQVBJRW5kcG9pbnRFeHRlbnNpb24sCiAgICAgICAgImNoZWNrQVBJS2V5Rm91bmQiOiBjaGVja0FQSUtleUZvdW5kLAogICAgICAgICJwcm9jZXNzRmllbGRKU09OIjogcHJvY2Vzc0ZpZWxkSlNPTiwKICAgICAgICAiZ2V0UmVxdWVzdGVkT3JkZXJTaXplcyI6IGdldFJlcXVlc3RlZE9yZGVyU2l6ZXMsCiAgICAgICAgImdldFJlcXVlc3RlZEJveGVzUGVyT2RlciI6IGdldFJlcXVlc3RlZEJveGVzUGVyT2RlciwKICAgICAgICAiZ2V0RGVjaXNpb25Db25maWciOiBnZXREZWNpc2lvbkNvbmZpZywKICAgICAgICAicG9wdWxhdGVPcmRlckluZm9TdHJpbmdzIjogcG9wdWxhdGVPcmRlckluZm9TdHJpbmdzLAogICAgICAgICJnZXRGaWVsZFNlbGVjdGlvbnNGb3JBbGxPcmRlcnMiOiBnZXRGaWVsZFNlbGVjdGlvbnNGb3JBbGxPcmRlcnMKICAgIH0gfTsKCn0pKCk7CgoKLy8gVG8gaW1wb3J0IGEgc2NyaXB0LCBpdCBtdXN0IHVzZSBhIHNpbWlsYXIgc3RydWN0dXJlIHRvIHRoZSBleGFtcGxlIGNvZGUgYWJvdmUuIEl0IHNob3VsZCB0YWtlIHRoZSBmb3JtIG9mCi8vIGFuIGltbWVkaWF0ZWx5IGludm9rZWQgZnVuY3Rpb24gZXhwcmVzc2lvbjogaHR0cHM6Ly9kZXZlbG9wZXIubW96aWxsYS5vcmcvZW4tVVMvZG9jcy9HbG9zc2FyeS9JSUZFIHdoZXJlIHRoZQovLyBmdW5jdGlvbiByZXR1cm5zIGEgZnVuY3Rpb24gbWFwIGNhbGxlZCBmdW5jTWFwLgovLyAKLy8gZnVuY01hcCBzaG91bGQgaGF2ZSBzdHJpbmcga2V5cyBhbmQgZnVuY3Rpb24gdmFsdWVzLiBTdHJpbmcga2V5cyB3aWxsIGJlIHVzZWQgYnkgRXZhbHVhdGFibGUgRWxlbWVudHMKLy8gdG8gcGFzcyBpbnB1dHMgdG8gYW5kIHJlY2VpdmUgb3V0cHV0cyBmcm9tIHRoZSBmdW5jdGlvbnMuCi8vIAovLyBFYWNoIHNjcmlwdCBtYXkgZGVmaW5lIGFyYml0cmFyaWx5IG1hbnkgZnVuY3Rpb25zLCBzbyBsb25nIGFzIHRoZXkncmUgYWxsIGV4cG9zZWQgdmlhIGZ1bmNNYXAuCi8vIAovLyBGdW5jdGlvbiBpbnB1dHMgd2lsbCB0YWtlIHRoZSBmb3JtIG9mIGEgc2luZ2xlIGFycmF5IG9mIDxhbnk+IHZhbHVlcy4KLy8gRnVuY3Rpb25zIHNob3VsZCBsaWtld2lzZSByZXR1cm4gYW4gYXJyYXkgb2YgPGFueT4gdmFsdWVzLgovLyBNZWFuaW5nIGZvciBhcmd1bWVudHMgYW5kIHJldHVybiB2YWx1ZXMgaXMgZGV0ZXJtaW5lZCBieSB0aGVpciBvcmRlciBpbiB0aGUgYXJyYXku"
+            }
+        }
+    ],
+    "controls": [
+        {
+            "meta": {
+                "uuid": "f9d4be6d-da7e-42de-b96c-9f5d42c5a082",
+                "name": "Field 1 State"
+            },
+            "inputOutputValues": [
+                "42f7bf91-3452-40b9-a1df-351c4a7c61df"
+            ],
+            "displays": [
+                "3eb1357a-008e-463b-ac16-526342c6f674"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "1b580dbf-6c6c-4b41-b0c6-0fc28040d8a6",
+                "name": "Field 2 State"
+            },
+            "inputOutputValues": [
+                "bcff236f-b29a-4214-80e9-b501423ab654"
+            ],
+            "displays": [
+                "d398c0d9-b822-4892-b839-de997621f2cb"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "0e0b47b0-bfde-46be-b7ad-8264f999fd38",
+                "name": "Field 3 State"
+            },
+            "inputOutputValues": [
+                "9d13ee13-1ca0-4333-aa91-84cbbfa6b389"
+            ],
+            "displays": [
+                "31440d95-7bcf-486e-aa9c-a7996e003fc4"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "e6cd87ef-e7f0-4d43-8a1e-94934f488985",
+                "name": "Field 4 State"
+            },
+            "inputOutputValues": [
+                "813d2baf-923c-497c-9511-fae72e8b6085"
+            ],
+            "displays": [
+                "456d4212-5650-4b5e-934a-21433564d598"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "ded28b3c-f426-4def-9690-9aaf02c5d784",
+                "name": "Field 5 State"
+            },
+            "inputOutputValues": [
+                "63262663-fd67-4e61-a4e3-23d69606324a"
+            ],
+            "displays": [
+                "1e37f5ad-8d6c-4bf3-a9d4-9fc0279346ea"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "57ee9943-1dec-4e1e-b531-a58c803fb999",
+                "name": "Field 6 State"
+            },
+            "inputOutputValues": [
+                "007b5928-6913-4337-9142-b8d72b7c746c"
+            ],
+            "displays": [
+                "571204ae-d4e6-4c52-8182-206dbad2bbfa"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "f94e98be-e733-4940-93b3-e5a6d58f4c55",
+                "name": "Field 7 State"
+            },
+            "inputOutputValues": [
+                "99808134-6298-4b6f-af10-dc052f9c0038"
+            ],
+            "displays": [
+                "8a9fd930-70e0-407b-bf4b-befce591cc95"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "31b0f8f5-91fc-4bc5-b2f7-4ff27be08239",
+                "name": "Field 8 State"
+            },
+            "inputOutputValues": [
+                "9949e3f9-0b8e-41d3-b627-40d856f7112d"
+            ],
+            "displays": [
+                "47278587-a146-4953-9be0-d4eabd2f2bb8"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "1e743b7a-b18b-46f7-b664-df1ee7ebdc6f",
+                "name": "D1O1 \"S\""
+            },
+            "inputOutputValues": [
+                "f540798b-6ffc-4a10-95f4-d07bcc3eb1aa"
+            ],
+            "displays": [
+                "9a6ea6d8-d620-4633-ad64-6b0073ecb55f"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "4cd6e60f-94c6-40da-8bf9-ffee37a2c39b",
+                "name": "D1O1 \"M\""
+            },
+            "inputOutputValues": [
+                "852e9d7a-3dbd-43e2-9f32-bbe27ca9379d"
+            ],
+            "displays": [
+                "c03bb373-7ac8-4dfc-93f4-fa0f780fb674"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "79d30f5d-d167-49db-a20e-3bbb795ec515",
+                "name": "D1O1 \"L1\""
+            },
+            "inputOutputValues": [
+                "99076810-7e7c-4e7e-b231-e2ece8fb78c4"
+            ],
+            "displays": [
+                "a4ef743e-1631-490b-8efd-994d8b6793a2"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "001dc475-b547-407f-8369-20867117eb56",
+                "name": "D1O1 \"L2\""
+            },
+            "inputOutputValues": [
+                "4e5fae8a-7ce6-4427-bff9-863186dd457e"
+            ],
+            "displays": [
+                "e3af891a-c3ce-4bfe-b1b3-fabbd89d0a83"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "0be431ed-7a71-4277-80c9-529cd0b1dea8",
+                "name": "D1O1 \"XL\""
+            },
+            "inputOutputValues": [
+                "74b14458-534c-41a8-a493-7fb342f3760d"
+            ],
+            "displays": [
+                "ed99124d-0c6f-422e-9cf6-601ad9713eef"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "90c164be-fb3d-4edb-94ae-a900af4f7044",
+                "name": "D1O1 \"G\""
+            },
+            "inputOutputValues": [
+                "dc7dca81-7543-4ca2-b2a1-44a108d385a7"
+            ],
+            "displays": [
+                "a5f8b630-ef29-4cd8-83de-9d68ae23ef58"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "d6f6dc94-868a-4847-a14b-7282d6bc69d3",
+                "name": "D1O2 \"S\""
+            },
+            "inputOutputValues": [
+                "64325833-330a-4e60-a6e2-731982997d04"
+            ],
+            "displays": [
+                "f83a26aa-e00f-472c-8c25-2d85d9bc3dcb"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "24665459-f2ad-4929-9ec4-67825a5b5f1f",
+                "name": "D1O2 \"M\""
+            },
+            "inputOutputValues": [
+                "122419a0-3eab-400a-bffe-7d0821d850ae"
+            ],
+            "displays": [
+                "209168ea-9b9c-4535-9813-7912856dd915"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "c6d6d99e-4e57-48a1-baac-bdc9308de52d",
+                "name": "D1O2 \"L1\""
+            },
+            "inputOutputValues": [
+                "2d11e584-b09c-48b8-b60c-ea328596a7d8"
+            ],
+            "displays": [
+                "4419314c-3d24-439d-87a9-b1a9c2341ec9"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "7535664f-3230-42da-9adb-2a9d4ac6c4c1",
+                "name": "D1O2 \"L2\""
+            },
+            "inputOutputValues": [
+                "b7d38390-eb3b-4777-9446-5a71fbaf3f6c"
+            ],
+            "displays": [
+                "e408c9a6-37a2-4602-a038-138d53cd2b3f"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "c06ef192-abc2-43d2-90c8-1f13e5600105",
+                "name": "D1O2 \"XL\""
+            },
+            "inputOutputValues": [
+                "4e9b7846-5649-43e2-a24b-e6acc7a14041"
+            ],
+            "displays": [
+                "06098baf-6dc8-478b-9063-9c0c03581a95"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "000513b8-bd49-450e-ba79-648d289f01c3",
+                "name": "D1O2 \"G\""
+            },
+            "inputOutputValues": [
+                "588ff155-0886-4267-891c-331f8dd597a1"
+            ],
+            "displays": [
+                "0b8ec058-acb8-478d-80bd-4da29a0fb068"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "1534d5d8-eb2f-42cf-a68f-0445df68be58",
+                "name": "D2O1 \"S\""
+            },
+            "inputOutputValues": [
+                "4fcb6038-2c20-4c5f-bbd9-2a8746caee5b"
+            ],
+            "displays": [
+                "fd7f9ad7-3f7f-487f-adef-c18acac2a192"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "188de09e-f230-4a57-a236-da3a2a13b3e4",
+                "name": "D2O1 \"M\""
+            },
+            "inputOutputValues": [
+                "38486fde-872e-4f3f-b7e7-c48c4494e7c9"
+            ],
+            "displays": [
+                "a6dabaa0-73dc-4b74-8921-0ca123599e4b"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "85789b9e-3c1c-4a35-a05c-721e8a17530b",
+                "name": "D2O1 \"L1\""
+            },
+            "inputOutputValues": [
+                "3009a4c2-a396-4935-9e41-916daeff3a4f"
+            ],
+            "displays": [
+                "6da70792-a406-4d91-a719-8ebe29561ee7"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "1ee41567-37cf-46d0-943a-0d4dff61d082",
+                "name": "D2O1 \"L2\""
+            },
+            "inputOutputValues": [
+                "42eec37f-6f05-4cdc-bfb9-8d7b9c363348"
+            ],
+            "displays": [
+                "c1ea62df-31fe-43fc-aa8c-1654de6560c1"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "cc356007-63b2-4db1-aa51-24eca7a99d74",
+                "name": "D2O1 \"XL\""
+            },
+            "inputOutputValues": [
+                "3f9d5d2f-2f7f-4f34-8c4f-aa45b01ac522"
+            ],
+            "displays": [
+                "e28d852c-500d-4215-9cf8-083c82d14887"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "a83e8f96-32d4-4f97-bca7-157b815b99e8",
+                "name": "D2O1 \"G\""
+            },
+            "inputOutputValues": [
+                "29e400b0-50e1-4aa4-9477-62a48cf4868b"
+            ],
+            "displays": [
+                "52f67042-43ea-464b-8b99-a7ccc39110a6"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "b875689a-050b-44e3-8957-fafda9f746c4",
+                "name": "D2O2 \"S\""
+            },
+            "inputOutputValues": [
+                "43da83a1-4197-4c38-a29f-54ea3a881bbb"
+            ],
+            "displays": [
+                "440aeab8-e4eb-48b2-8987-0da58b41297f"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "6bfae690-12f1-4c21-94ea-dc6aa1273bf4",
+                "name": "D2O2 \"M\""
+            },
+            "inputOutputValues": [
+                "63b16da1-ca85-4332-9b72-02c77b82be71"
+            ],
+            "displays": [
+                "431f0922-2834-4933-8faa-a6bb8a6961a8"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "21431f15-7641-41d2-8b7e-6dc5ff29e8d6",
+                "name": "D2O2 \"L1\""
+            },
+            "inputOutputValues": [
+                "ec309d92-7210-4b18-ae92-d8c8710864bb"
+            ],
+            "displays": [
+                "b68d110e-20d6-45f3-a225-47b71cd1714d"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "9b6a2e63-d77b-4b4a-8aa7-1a22ee6e0e2f",
+                "name": "D2O2 \"L2\""
+            },
+            "inputOutputValues": [
+                "46512069-cf25-4a54-969e-8cc58b6d0d64"
+            ],
+            "displays": [
+                "4af9ea19-4cbd-4b1a-bbcf-3ed4ee457dec"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "48fd9bd1-1fcf-481b-a04c-81f74115cdbf",
+                "name": "D2O2 \"XL\""
+            },
+            "inputOutputValues": [
+                "b48fbe16-82f3-4816-ace6-226f6c4abb19"
+            ],
+            "displays": [
+                "203bfc23-1dde-4a9f-8bc9-c100c0b7b3b6"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "47587b01-0d04-4f92-970c-b5cd3bead5ce",
+                "name": "D2O2 \"G\""
+            },
+            "inputOutputValues": [
+                "572d663e-ce15-482b-b2cd-7fdafc3849da"
+            ],
+            "displays": [
+                "32cd7599-95cf-4e48-ba5a-08da41609537"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "8dd666ac-94f9-406b-8b73-abfef8c6b5c7",
+                "name": "D1O1 Boxes"
+            },
+            "inputOutputValues": [
+                "5bbae604-6eec-4b3e-8a0a-322e9a3ebfb9"
+            ],
+            "displays": [
+                "28228cb4-f30c-47ef-ac29-da0e2f65479b"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "d375f9d9-34e2-49a4-879a-788a414ed701",
+                "name": "D1O2 Boxes"
+            },
+            "inputOutputValues": [
+                "713df129-6ebb-4469-b620-62f1d0b51899"
+            ],
+            "displays": [
+                "9cc14bac-dcec-424d-8212-26fbd4627966"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "783cf8a6-4ca9-4745-9d50-69a6b44f1367",
+                "name": "D2O1 Boxes"
+            },
+            "inputOutputValues": [
+                "ed143517-e7a2-4852-88ad-be5bab8e393a"
+            ],
+            "displays": [
+                "c5c5e7a6-721c-440c-bcab-ffa4020f933a"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "701acd4e-bc82-4fc2-9cc6-b38780ba24fc",
+                "name": "D2O2 Boxes"
+            },
+            "inputOutputValues": [
+                "02cbc8d6-3079-42de-8f69-30f3a33f6da0"
+            ],
+            "displays": [
+                "c749d2b1-eacd-4c66-a36f-0a0790764257"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "dcddb94c-13af-4c7f-84ff-2f6a68be0255",
+                "name": "D1O1 Info String"
+            },
+            "inputOutputValues": [
+                "fda8ca0f-7948-4194-bf73-c6dcf968209c"
+            ],
+            "displays": [
+                "8426bfcd-b066-4451-8eb3-c7b29d2cf142"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "c792ebe3-0799-44a0-b72e-87f59251ec49",
+                "name": "D1O2 Info String"
+            },
+            "inputOutputValues": [
+                "970876ef-74ff-428a-a993-63d331f32ef4"
+            ],
+            "displays": [
+                "e3ff32e1-cbfd-45c4-b7b2-09b6cf07e0a6"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "e70094c9-8601-490b-9edf-bcbfd935589a",
+                "name": "D2O1 Info String"
+            },
+            "inputOutputValues": [
+                "6cc8178d-2ce1-4357-8894-640264c23a13"
+            ],
+            "displays": [
+                "528dfb5f-0ec0-435e-9cb0-b04756916283"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "56ab38a5-edd1-4bf5-bcd3-77b39988c439",
+                "name": "D2O2 Info String"
+            },
+            "inputOutputValues": [
+                "62755287-41a9-4b84-8dc5-cf4e5136a653"
+            ],
+            "displays": [
+                "622144cf-2fda-40e3-9a90-a1cd6c61e60b"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "7d2bd598-75c7-458d-aac2-885bc4fe38bc",
+                "name": "Boxes Packed D1O1"
+            },
+            "inputOutputValues": [
+                "438d09fe-2d3d-4ad6-9444-ff9c6a8c14e7",
+                "267e8d98-6c18-4111-b12b-57e926ba87a1",
+                "5bbae604-6eec-4b3e-8a0a-322e9a3ebfb9"
+            ],
+            "displays": [
+                "80e6381e-53fb-455b-909d-83b61e33a61a"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "a4ea4adc-828f-4d8c-93b0-41b938b80256",
+                "name": "Boxes Packed D1O2"
+            },
+            "inputOutputValues": [
+                "12b045f7-a0a4-48e3-ab5d-97a50b8831a7",
+                "267e8d98-6c18-4111-b12b-57e926ba87a1",
+                "713df129-6ebb-4469-b620-62f1d0b51899"
+            ],
+            "displays": [
+                "ebd26454-c9b4-42f2-8a61-4c9172c0039a"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "c0f162a3-b525-4096-a83d-a44b0f3127b4",
+                "name": "Boxes Packed D2O1"
+            },
+            "inputOutputValues": [
+                "3a9d5227-2e8c-4a75-af5d-6f0d54111251",
+                "267e8d98-6c18-4111-b12b-57e926ba87a1",
+                "ed143517-e7a2-4852-88ad-be5bab8e393a"
+            ],
+            "displays": [
+                "03fabdc4-4df0-4542-a8ae-8f293b5cdff4"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "43e6e3a7-57c4-4916-a08c-5d16fe5c42f2",
+                "name": "Boxes Packed D2O2"
+            },
+            "inputOutputValues": [
+                "bbaac339-a870-4ac5-9f35-36da8fe9e864",
+                "267e8d98-6c18-4111-b12b-57e926ba87a1",
+                "02cbc8d6-3079-42de-8f69-30f3a33f6da0"
+            ],
+            "displays": [
+                "e550b053-007d-47de-9cf4-273c8821182c"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "a88a1e5f-997d-4c40-bf24-43e8f9403b6b",
+                "name": "Field Selection: D1O1 S1"
+            },
+            "inputOutputValues": [
+                "c3210bb6-a1aa-443c-ae66-4904b3dcc57d"
+            ],
+            "displays": [
+                "7578c0c2-0fab-43b0-80fc-43310416949e"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "bf9ce526-a20f-4c83-b8e3-151a9d6462a3",
+                "name": "Field Selection: D1O1 S2"
+            },
+            "inputOutputValues": [
+                "aab47c8d-edee-43ef-ae29-893e9ba3cac9"
+            ],
+            "displays": [
+                "d32da97a-1ecb-4a07-93d9-fb32dd94d529"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "8e43f8a2-7fba-45bf-9ac6-138c5533ab35",
+                "name": "Field Selection: D1O1 S3"
+            },
+            "inputOutputValues": [
+                "ace9103e-b6ad-42cd-87c4-7c8dbc3073af"
+            ],
+            "displays": [
+                "6b31aac7-228d-4487-b4be-f2b63508456d"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "455aa89a-c993-4f59-bbbc-2e5ed6c43769",
+                "name": "Field Selection: D1O2 S1"
+            },
+            "inputOutputValues": [
+                "39f6742e-3f6c-436c-a009-41069451ff68"
+            ],
+            "displays": [
+                "81058753-5c19-4278-88b3-eff4d202c80b"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "053009af-2ff0-4b3d-89e9-d42e4912e92a",
+                "name": "Field Selection: D1O2 S2"
+            },
+            "inputOutputValues": [
+                "c2abcd03-00d3-4247-acaf-7adbdf60a9c8"
+            ],
+            "displays": [
+                "7a435e55-ebdb-416c-b37f-0004b81b84dc"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "39a4a6f9-ab7c-465a-a6bd-a1ca28e396fb",
+                "name": "Field Selection: D1O2 S3"
+            },
+            "inputOutputValues": [
+                "54c2667d-1b16-44a2-9c30-dbcce982e3c0"
+            ],
+            "displays": [
+                "07fdf1f2-8192-4ccb-80a8-1c4894623fee"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "6de40510-21cc-42ad-86c8-c0d5a3f8a190",
+                "name": "Field Selection: D2O1 S1"
+            },
+            "inputOutputValues": [
+                "bca66c5b-915b-4732-8d66-3c650a251398"
+            ],
+            "displays": [
+                "409a13e2-d2f5-4833-97ab-8436fbef8758"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "950388d9-275f-4ef5-8f64-46e496034524",
+                "name": "Field Selection: D2O1 S2"
+            },
+            "inputOutputValues": [
+                "0a1527ea-bce6-4571-9f00-b5db62611532"
+            ],
+            "displays": [
+                "f6a1e740-cd83-4941-bf0e-cd51bb097d2e"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "53ea9045-6857-4eeb-ab2b-653cd1417ba7",
+                "name": "Field Selection: D2O1 S3"
+            },
+            "inputOutputValues": [
+                "23b0018e-4d99-4ecb-88f4-3e382bd846a2"
+            ],
+            "displays": [
+                "f77f594f-e82b-4472-95aa-dfd57b91d636"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "efde2d22-21db-4938-bc4e-e65c50649a07",
+                "name": "Field Selection: D2O2 S1"
+            },
+            "inputOutputValues": [
+                "973752e2-ec80-4d1e-a1eb-640a67c0eddc"
+            ],
+            "displays": [
+                "e9c50169-24c1-43dc-9b61-3fc029d00322"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "cb72dd83-e256-4061-aee2-442d3c007564",
+                "name": "Field Selection: D2O2 S2"
+            },
+            "inputOutputValues": [
+                "70e2d74f-34a5-46c5-bb6c-6d15cb8b37f8"
+            ],
+            "displays": [
+                "d1deed13-8b21-4270-ab5a-1b3ca8cfcb0d"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "d6d9c183-a724-4466-b17c-781936362ad3",
+                "name": "Field Selection: D2O2 S3"
+            },
+            "inputOutputValues": [
+                "3935c9a1-4e1d-4c27-ad47-7d5b42225bcf"
+            ],
+            "displays": [
+                "d434d075-38ed-4083-b37f-b8d45fd128dc"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "ae3892b2-4d22-4c29-a209-c5e9d3ecd10f",
+                "name": "Storage: D1O1"
+            },
+            "inputOutputValues": [
+                "b8787e50-1e79-494a-9475-eb1f25c7c70b"
+            ],
+            "displays": [
+                "9c855284-820f-49f6-8ad4-6c0c802e80d0"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "71ba9203-47fd-4b17-8df8-88bdcd62aee7",
+                "name": "Storage: D1O2"
+            },
+            "inputOutputValues": [
+                "cf48172b-a508-42c0-a99b-3fe11b8c0be8"
+            ],
+            "displays": [
+                "680476a3-a09e-4ab6-acf5-8756106fd0b9"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "cae2196a-749c-43d4-8376-2b88aefb8f9f",
+                "name": "Storage: D2O1"
+            },
+            "inputOutputValues": [
+                "0061b32f-309c-4069-b2cb-cd4aaf76b59f"
+            ],
+            "displays": [
+                "26c69bb8-9b54-4984-ba4e-6e33fc92a971"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "2fa5b8a9-31de-4ae7-9c26-c4632bbf7c83",
+                "name": "Storage: D2O2"
+            },
+            "inputOutputValues": [
+                "00277ca1-a9ea-474f-9f22-4bac0829cb25"
+            ],
+            "displays": [
+                "112c31b2-5d41-4d1b-ad2a-d433bad067e4"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "550151d4-87bd-47d7-9c3a-6b0f52d6876f",
+                "name": "Cost/Revenue Split"
+            },
+            "inputOutputValues": [
+                "760d9ec4-ba18-41b6-867c-cc89d9d6afe3"
+            ],
+            "displays": [
+                "1399d32f-20fa-46b3-912d-3fda5484fd89"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "712fb8f2-19f6-4cdf-a083-c24e90325c53",
+                "name": "Profit"
+            },
+            "inputOutputValues": [
+                "131747d0-00a3-474e-ad2d-10016a9f9be3"
+            ],
+            "displays": [
+                "f9178bd2-2ca5-484f-b1ad-f1b033904c95"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "f59d13c9-d10c-4ae5-94a8-eb773a66a1ae",
+                "name": "Config: API Key"
+            },
+            "inputOutputValues": [
+                "d2615f0e-df57-478f-909d-5f2b71ff9621"
+            ],
+            "displays": [
+                "3296090f-27ad-4aec-8e50-7aa1040bcb44"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "33018365-114d-4e49-9100-a452896ada2a",
+                "name": "Config: Wages"
+            },
+            "inputOutputValues": [
+                "988b4330-3650-4fd9-9f07-9b7dbf505507"
+            ],
+            "displays": [
+                "d773bf51-e288-48c2-8017-5b20957d9a5b"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "a4f956aa-d038-4085-86ec-74d4256f8b59",
+                "name": "Config: Time to harvest 1 pound"
+            },
+            "inputOutputValues": [
+                "41791496-99c2-4090-9461-94043255ba3b"
+            ],
+            "displays": [
+                "7c3233f5-9e8e-4c9a-820c-d8efd467a0c8"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "e06a6f82-5773-4bbd-aed9-66f341b228ee",
+                "name": "Config: Field Switching Flat Cost"
+            },
+            "inputOutputValues": [
+                "f2a0301d-667d-4104-acd2-7f937447a18e"
+            ],
+            "displays": [
+                "56c9084f-c987-4e7e-bc05-7df2199bf960"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "2a2e2c45-4b36-4109-a9f7-01a844b9c330",
+                "name": "Config: Field Switching Time"
+            },
+            "inputOutputValues": [
+                "75fab4bd-8594-4b3f-8cfb-8f9cdfec1c3d"
+            ],
+            "displays": [
+                "09e16ef5-5449-4298-abae-8275829cc622"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "cb43c940-b6a7-4427-b26a-6d92d845c8c0",
+                "name": "Config: Storage Cost"
+            },
+            "inputOutputValues": [
+                "f8429046-8bbc-4df8-a06f-11e5685a6982"
+            ],
+            "displays": [
+                "84a2373b-c21f-435f-8827-d98a1cf4cb98"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "c8c10e86-63b7-41a7-b8e3-0fb389521835",
+                "name": "Config: Revenue Per Box"
+            },
+            "inputOutputValues": [
+                "75d48c06-4c46-4d08-972d-e3dd35ed1e15"
+            ],
+            "displays": [
+                "33871b7f-f8de-4e56-bc46-6a9b6f35389f"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "dbe14669-ca48-4773-b413-028d971e0c5f",
+                "name": "Config: Orders Per Day"
+            },
+            "inputOutputValues": [
+                "d52d11c9-6ffe-4201-8d83-0e8603fefa1f"
+            ],
+            "displays": [
+                "05a6ed20-76ac-415c-a86f-317c1d3a98a9"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "ae3cbebe-5722-4601-847e-e40150b31fe3",
+                "name": "API Key Note"
+            },
+            "inputOutputValues": [
+                "27aed0e0-84c8-4db9-a369-b3c809c09046"
+            ],
+            "displays": [
+                "f9c7323f-085b-48d9-9024-163a04ff781f"
+            ]
+        },
+        {
+            "meta": {
+                "uuid": "0d54aa22-bba0-43e4-b0fc-ded893394679",
+                "name": "Config: Storage cost frequency"
+            },
+            "inputOutputValues": [
+                "55678c78-4b7a-413e-be6f-972baae59ad7"
+            ],
+            "displays": [
+                "b48a746d-3378-4ca1-b121-d361dcd00666"
+            ]
+        }
+    ]
+}

--- a/src/model_json/builtin-examples/builtinModels.tsx
+++ b/src/model_json/builtin-examples/builtinModels.tsx
@@ -1,4 +1,5 @@
 import ExampleCoffee from  "./coffee.json" assert { type: "json" };
+import ExamplePotatoPacking from "./Sweet_Potato_Packing.json" assert { type: "json" };
 import ExampleCoffeeNonInteractive from "./coffee_noninteractive.json" assert { type: "json" };
 import ExampleBasicAdder from "./Range_Demo_Basic_Adder.json" assert { type: "json" };
 import ExampleMultistepAdder from "./Range_Demo_Multistep_Adder.json" assert { type: "json" };
@@ -27,6 +28,7 @@ export type BuiltInModelRecord = {
 export const BuiltInModels: Record<string, BuiltInModelRecord> = {};
 [
     ExampleCoffee,
+    ExamplePotatoPacking,
     ExampleCoffeeNonInteractive,
     ExampleBasicAdder,
     ExampleMultistepAdder,


### PR DESCRIPTION
Implemented a basic (synchronously evaluated) API Call evaluatable asset.  
JSON Schema definition here: https://github.com/opendi-org/cdm-json-schema/commit/1023d3f3e206d032c97510b0dbcdb468a930a62f

This implementation leaves lots of room for improvement regarding the way model evaluation handles API calls and other potential future *asynchronous* elements.

For now, API calls are naturally `await`ed so that future evaluatable elements that depend on their outputs don't break.  
So they're working properly, and they can be used in a way that is roughly equivalent to scripts, but this also means that evaluation hangs on any API call until it receives a response.

To help mitigate this, the authoring tool maintains a cache of API requests and results, so if an evaluatable asset makes an API call that is identical to one it recently made, it can immediately return the same response from a cache, instead of making the call again and hanging while awaiting a response.  
This behavior can be disabled by setting the cache size to 0 in the evaluatable element's JSON data.

This feature also includes a new example model: the sweet potato packing model.  
This model simulates a realistic decision that impacts the sweet potato value chain, and it also relies heavily on spreadsheet data retrieved via an API call. For more detail on this model, see the model summary in the JSON (preferably by loading the model in a test environment, or once this PR is accepted, in the live environment).