### PR TITLE
Fix links from Gamma site migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Containerized Authoring Demo provides more complete functionality, including
 
 ## Live Test
 You can try this tool out yourself!  
-Visit https://opendi.org/cdd-authoring-tool/  
+Visit https://opendi-org.github.io/cdd-authoring-tool/  
 **See warning below.**
 
 ### Warning

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -248,10 +248,10 @@ function App() {
                         <div>
                             <h3>OpenDI</h3>
                             <ul>
-                                <li><a href="http://opendi.org/" target="_blank">Main Site</a></li>
-                                <li><a href="http://opendi.org/roles-user-stories" target="_blank">Roles and User Stories</a></li>
-                                <li><a href="http://opendi.org/api-specification" target="_blank">API Specification</a></li>
-                                <li><a href="http://opendi.org/cdd-authoring-tool" target="_blank">CDM Authoring Tool</a></li>
+                                <li><a href="https://opendi.org/" target="_blank">Main Site</a></li>
+                                <li><a href="https://opendi-org.github.io/roles-user-stories/" target="_blank">Roles and User Stories</a></li>
+                                <li><a href="https://opendi-org.github.io/api-specification/" target="_blank">API Specification</a></li>
+                                <li><a href="https://opendi-org.github.io/cdd-authoring-tool/" target="_blank">CDM Authoring Tool</a></li>
                             </ul>
                         </div>
                     </div>

--- a/src/components/RightMenu/GlossaryTab.tsx
+++ b/src/components/RightMenu/GlossaryTab.tsx
@@ -7,13 +7,13 @@ import React from "react";
 const GlossaryTab: React.FC = () => {
     return (
         <>
-            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/OpenDI%20Glossary#lever">Lever</a></h2>
-            <p>Represents an <a target="_blank" rel="noopener noreferrer" href="https://opendi.org/OpenDI%20Glossary#action">Action</a> directly within the decision maker's control.</p>
-            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/OpenDI%20Glossary/#intermediate">Intermediate</a></h2>
+            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/glossary#lever">Lever</a></h2>
+            <p>Represents an <a target="_blank" rel="noopener noreferrer" href="https://opendi.org/glossary#action">Action</a> directly within the decision maker's control.</p>
+            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/glossary#intermediate">Intermediate</a></h2>
             <p>Consequence of the decision maker's actions which impact the outcomes of the decision.</p>
-            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/OpenDI%20Glossary/#outcome">Outcome</a></h2>
+            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/glossary#outcome">Outcome</a></h2>
             <p>A result of a decision the decision maker is interested in measuring.</p>
-            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/OpenDI%20Glossary/#external">External</a></h2>
+            <h2><a target="_blank" rel="noopener noreferrer" href="https://opendi.org/glossary#external">External</a></h2>
             <p>Represents something outside the decision maker's control that have an impact on outcomes, either directly or indirectly.</p>
         </>
     )


### PR DESCRIPTION
Gamma migration broke the old opendi.org links for Roles/User Stories, API Spec, and CDD Authoring Tool. These have been reverted to their github.io links.  
We also have a new link for the Gamma-hosted glossary.

- https://opendi.org/roles-user-stories -> https://opendi-org.github.io/roles-user-stories/
- https://opendi.org/api-specification -> https://opendi-org.github.io/api-specification/
- https://opendi.org/cdd-authoring-tool -> https://opendi-org.github.io/cdd-authoring-tool/

Fixed links in README, site footer, and the tool's glossary tab.

NOTE: The Gamma glossary page currently doesn't handle anchor links, so while the links still ATTEMPT to navigate to the specific term, right now they just go to the top of the glossary page.